### PR TITLE
fix: navigate to home page after logout (Fixes #20)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -4380,6 +4380,7 @@ async function logout() {
     await api('/api/auth/logout', { method: 'POST', body: JSON.stringify({}) });
   } finally {
     clearSession();
+    openPublicPage('home');
     showToast('Logged out.');
   }
 }


### PR DESCRIPTION
## Summary
Fixes #20 — Logout bug where user gets stuck on authenticated dashboard view.

## Root Cause
The `logout()` function calls `clearSession()` to clear token, user state, and dashboard data, but does **not** navigate the user away from the dashboard. After logout, the UI remains on the authenticated dashboard view with broken/empty state.

## Fix
Added `openPublicPage("home")` after `clearSession()` in the logout function:

```javascript
async function logout() {
  try {
    await api("/api/auth/logout", { method: "POST", body: JSON.stringify({}) });
  } finally {
    clearSession();
    openPublicPage("home");
    showToast("Logged out.");
  }
}
```

## Why This Fix
- Uses existing `openPublicPage()` function (consistent with codebase)
- Navigates to `"home"` (valid public page)
- `openPublicPage()` handles: setting `publicModeVisible`, updating `publicPage`, updating browser URL, scrolling to top
- One line change — minimal, safe, no regressions

## Claim
- Claim comment: https://github.com/mergeos-bounties/mergeos/issues/20#issuecomment-4546047551
- Bounty: 200 MRG

## Testing
- [x] Logout clears token and session state
- [x] User is redirected to home page after logout
- [x] Browser URL updates to `/`
- [x] Re-login works normally after logout\n\n---\n**Claim info:**\nGitHub handle: kejuunuy\nWallet: 0x96e04aC80b9b18ddbfB7e921800feF673BC1CA26
