### PR TITLE
feat: add project mode selector for new vs bugfix (Fixes #12)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -136,10 +136,39 @@
                 v-model.trim="projectSetupForm.shortDescription"
                 rows="5"
                 maxlength="1000"
-                placeholder="Describe your project, what you want to build, and the problem you're solving..."
+                :placeholder="projectSetupForm.projectMode === 'bugfix' ? 'Describe the bug, steps to reproduce, and expected behavior...' : 'Describe your project, what you want to build, and the problem you're solving...'"
               />
               <small>{{ projectSetupForm.shortDescription.length }} / 1000</small>
             </label>
+
+            <section class="wizard-section full">
+              <div class="wizard-section-title">
+                <strong>Project mode <b>*</b></strong>
+                <small>Are you starting fresh or fixing something?</small>
+              </div>
+              <div class="project-mode-selector">
+                <button
+                  :class="{ selected: projectSetupForm.projectMode === 'new' }"
+                  class="project-mode-tile"
+                  type="button"
+                  @click="projectSetupForm.projectMode = 'new'"
+                >
+                  <span class="mode-icon"><Lightbulb :size="20" /></span>
+                  <strong>New project</strong>
+                  <small>Start a brand-new project or idea from scratch</small>
+                </button>
+                <button
+                  :class="{ selected: projectSetupForm.projectMode === 'bugfix' }"
+                  class="project-mode-tile"
+                  type="button"
+                  @click="projectSetupForm.projectMode = 'bugfix'"
+                >
+                  <span class="mode-icon"><Bug :size="20" /></span>
+                  <strong>Fix existing project</strong>
+                  <small>Fix a bug or issue in an existing repo or product</small>
+                </button>
+              </div>
+            </section>
 
             <section class="wizard-section full">
               <div class="wizard-section-title">
@@ -2390,6 +2419,7 @@ const repoImportResult = ref(null);
 let dashboardRefreshTimer = 0;
 
 const projectSetupForm = reactive({
+  projectMode: 'new',
   title: '',
   shortDescription: '',
   projectType: '',
@@ -2453,14 +2483,25 @@ const projectSetupSteps = [
   },
 ];
 
-const projectTypeOptions = [
+const projectTypeOptionsNew = [
   { label: 'Web Development', caption: 'Web apps', icon: Globe2 },
-  { label: 'Repo Issue Fix', caption: 'Existing repo', icon: Bug },
   { label: 'Mobile Development', caption: 'iOS and Android', icon: Compass },
   { label: 'AI / ML', caption: 'Agents and models', icon: Bot },
   { label: 'Smart Contract', caption: 'Web3', icon: Link2 },
   { label: 'Other', caption: 'Custom work', icon: MoreHorizontal },
 ];
+
+const projectTypeOptionsBugfix = [
+  { label: 'Bug Fix', caption: 'Fix a specific bug', icon: Bug },
+  { label: 'Performance', caption: 'Optimize speed', icon: Zap },
+  { label: 'Security', caption: 'Patch vulnerability', icon: ShieldCheck },
+  { label: 'UI/UX', caption: 'Fix interface issues', icon: Layout },
+  { label: 'Other', caption: 'Custom fix', icon: MoreHorizontal },
+];
+
+const projectTypeOptions = computed(() =>
+  projectSetupForm.projectMode === 'bugfix' ? projectTypeOptionsBugfix : projectTypeOptionsNew
+);
 
 const budgetTypeOptions = [
   { label: 'Fixed price', icon: CircleDollarSign },

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -7990,3 +7990,70 @@ svg {
     grid-template-columns: 1fr;
   }
 }
+
+/* ===== Project type selector (Bounty #12) ===== */
+
+.project-mode-selector {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.project-mode-tile {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 20px 16px;
+  border: 2px solid #e5e7eb;
+  border-radius: 10px;
+  background: #fff;
+  cursor: pointer;
+  transition: all 160ms ease;
+  text-align: center;
+}
+
+.project-mode-tile:hover {
+  border-color: #93c5fd;
+  background: #f0f7ff;
+}
+
+.project-mode-tile.selected {
+  border-color: #3b82f6;
+  background: #eff6ff;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+}
+
+.project-mode-tile strong {
+  font-size: 15px;
+  font-weight: 750;
+  color: #111827;
+}
+
+.project-mode-tile small {
+  font-size: 12px;
+  color: #6b7280;
+  line-height: 1.4;
+}
+
+.project-mode-tile .mode-icon {
+  width: 40px;
+  height: 40px;
+  display: grid;
+  place-items: center;
+  border-radius: 10px;
+  background: #f1f5f9;
+  color: #475569;
+}
+
+.project-mode-tile.selected .mode-icon {
+  background: #3b82f6;
+  color: #fff;
+}
+
+@media (max-width: 520px) {
+  .project-mode-selector {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
Fixes #12 — Add clear separation between "New project" and "Fix bug in existing project" in the create-project flow.

## Implementation

### Project Mode Selector
Added a visual tile selector at the start of Step 1 that lets users choose:
- **New project** (Lightbulb icon) — Start a brand-new project or idea from scratch
- **Fix existing project** (Bug icon) — Fix a bug or issue in an existing repo or product

### Dynamic Project Types
Project type options change based on selected mode:

**New project mode:**
- Web Development
- Mobile Development
- AI / ML
- Smart Contract
- Other

**Bug fix mode:**
- Bug Fix
- Performance
- Security
- UI/UX
- Other

### Dynamic Placeholders
Short description placeholder text adapts to the selected mode:
- New: "Describe your project, what you want to build, and the problem you're solving..."
- Bugfix: "Describe the bug, steps to reproduce, and expected behavior..."

## UI/UX
- Clean tile-based selector with icons
- Selected state: blue border + icon highlight
- Responsive: stacks vertically on mobile (520px)
- Realistic placeholder content (no dummy text)

## Changes
- `frontend/src/App.vue` — Added projectMode field, dynamic options, mode selector UI
- `frontend/src/styles.css` — Added 67 lines of CSS for mode selector

## Claim
- Claim comment: https://github.com/mergeos-bounties/mergeos/issues/12#issuecomment-4546528045
- Bounty: 3000 MRG
- Wallet: `0x96e04aC80b9b18ddbfB7e921800feF673BC1CA26`\n\n---\n**Claim info:**\nGitHub handle: kejuunuy\nWallet: 0x96e04aC80b9b18ddbfB7e921800feF673BC1CA26
