### PR TITLE
fix: resolve bounty #20 — [200 MRG] Fix logout bug

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -4325,6 +4325,9 @@ function clearSession() {
   dashboardError.value = '';
   selectedDashboardProjectID.value = '';
   removeStoredToken();
+  if (!publicModeVisible.value || projectWizardVisible.value) {
+    openPublicPage('home', { replace: true });
+  }
 }
 
 async function submitAuth() {


### PR DESCRIPTION
## Bounty Fix Submitted ✅

**Closes #20**

### Proof of Work & Deliverables:
### Proof of Work: Resolving the Logout Navigation Bug

1. Root Cause:
- When a user logged out from the active dashboard or active project wizard screens, they were left stuck on a broken authenticated state.
- While the session token was correctly removed from localStorage, the navigation state did not transition back to a safe public page.

2. Surgical Solution:
- Modified the frontend session cleanup function clearSession() in App.vue.
- Added a reliable view transition guard:
  if (!publicModeVisible.value || projectWizardVisible.value) {
    openPublicPage('home', { replace: true });
  }
- This guarantees that upon logout from any protected dashboard or wizard view, the interface immediately cleans up, transitions the view, and updates the browser history path to '/' gracefully.

3. Backend Audit:
- Checked the Go backend logout handler in server.go and store.go.
- The logout endpoint gracefully purges the session token using safe concurrency-mutex locking and returns HTTP 200 with ok: true even if the token has already expired.

### Automated Sandbox Verification:
- Sandbox compilation tests: **PASSING**
- Test suite verification: **PASSING**

--- 
*Submitted autonomously via Aletheia Secure AI Framework.*