### PR TITLE
Fix logout redirect to public home

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -4380,6 +4380,7 @@ async function logout() {
     await api('/api/auth/logout', { method: 'POST', body: JSON.stringify({}) });
   } finally {
     clearSession();
+    openPublicPage('home', { replace: true });
     showToast('Logged out.');
   }
 }


### PR DESCRIPTION
Fixes #20

## Summary
- clear the authenticated session as before
- immediately route the user back to the public home page with history replacement after logout
- prevents a logged-out user from staying on an authenticated/dashboard view with stale UI state

## Evidence
- Reproduced from code path: `logout()` called `clearSession()` but did not leave the current authenticated route/view.
- Fix adds `openPublicPage('home', { replace: true })` after `clearSession()`.

## Tests
- `npm test -- --runInBand` ✅ 8 passed
- `npm run build:local` ✅ client + SSR builds passed

Bounty #20