### PR TITLE
Improve auth modal on small screens

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -6172,6 +6172,15 @@ svg {
     padding: 30px 20px 24px;
   }
 
+  .auth-form {
+    min-width: 0;
+  }
+
+  .auth-submit-button,
+  .social-auth-row button {
+    width: 100%;
+  }
+
   .auth-close-button {
     top: 16px;
     right: 16px;
@@ -6202,6 +6211,53 @@ svg {
 }
 
 @media (max-width: 520px) {
+  .modal-backdrop {
+    align-items: start;
+    padding: 10px;
+  }
+
+  .auth-modal {
+    width: 100%;
+    max-height: calc(100dvh - 20px);
+    border-radius: 12px;
+  }
+
+  .auth-modal-main {
+    gap: 18px;
+    padding: 22px 14px 18px;
+  }
+
+  .auth-close-button {
+    top: 10px;
+    right: 10px;
+    width: 34px;
+    height: 34px;
+  }
+
+  .auth-copy {
+    margin-top: 20px;
+    padding-right: 32px;
+  }
+
+  .auth-divider {
+    margin: 14px 0 12px;
+  }
+
+  .auth-option-row {
+    gap: 10px;
+    margin-bottom: 14px;
+  }
+
+  .input-shell {
+    grid-template-columns: 20px minmax(0, 1fr) auto;
+    gap: 8px;
+    padding: 0 12px;
+  }
+
+  .input-shell input {
+    font-size: 16px;
+  }
+
   .primary-button.compact {
     padding: 0 12px;
   }


### PR DESCRIPTION
Fixes #13.

Changes:
- Tightened auth modal spacing and close-button placement for <=520px viewports.
- Forces social + submit buttons to full width on narrow layouts.
- Uses 100dvh modal max-height and smaller mobile padding so controls remain reachable after resize.
- Sets login inputs to 16px on mobile to avoid browser zoom/layout jumps.

Verification:
- npm --prefix frontend run build:local passes.
- Reviewed target responsive widths from the bounty: 430px, 390px, 360px.

Evidence/artifacts kept locally in money-work/20260527_0230.
