### PR TITLE
fix: invalidate all user sessions on logout and clear frontend state

### DIFF
--- a/admin/src/App.vue
+++ b/admin/src/App.vue
@@ -1374,9 +1374,31 @@ async function mergeTaskPull(task, pull) {
 
 function logout(callApi = true) {
   const currentToken = token.value;
+  // Clear all auth and UI state so the dashboard never shows stale data
   token.value = '';
   adminUser.value = null;
+  summary.value = {};
+  users.value = [];
+  projects.value = [];
+  tasks.value = [];
+  notifications.value = [];
+  ledgerEntries.value = [];
+  sslRows.value = [];
+  geminiKeys.value = [];
+  geminiWebhookLogs.value = [];
+  taskPulls.value = {};
+  taskPullsLoaded.value = {};
+  taskPullsLoading.value = {};
+  taskPullsError.value = {};
+  mergeBusy.value = {};
+  mergeMessages.value = {};
+  mergeSelections.value = {};
+  expandedTaskPulls.value = {};
+  errorMessage.value = '';
+  selectedUserId.value = '';
   if (hasWindow) localStorage.removeItem(storageKey);
+  // Navigate to the login/root view
+  setActiveView('builder', { replace: true });
   if (callApi && currentToken) {
     fetch('/api/auth/logout', {
       method: 'POST',

--- a/backend/internal/core/store.go
+++ b/backend/internal/core/store.go
@@ -292,7 +292,17 @@ func (s *Store) Logout(token string) {
 	token = strings.TrimSpace(strings.TrimPrefix(token, "Bearer "))
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	delete(s.sessions, token)
+	// Find the user for this token so we can invalidate ALL their sessions
+	if session, ok := s.sessions[token]; ok {
+		userID := session.UserID
+		for t, sess := range s.sessions {
+			if sess.UserID == userID {
+				delete(s.sessions, t)
+			}
+		}
+	} else {
+		delete(s.sessions, token)
+	}
 	_ = s.saveLocked()
 }
 


### PR DESCRIPTION
## Summary

Fixes #20 and #23 — two logout-related bugs:

### Backend fix (`store.go`)
The `Logout()` function previously only deleted the single token from the Authorization header. If a user had multiple active sessions (different devices/browsers), logging out from one left all other sessions fully active.

**Now:** Logout looks up the user ID from the session token, then iterates and deletes ALL sessions belonging to that user. This ensures a complete logout across all devices.

### Frontend fix (`App.vue`)
The `logout()` function previously only cleared `token` and `adminUser` refs. All other reactive state (projects, tasks, ledger, SSL, gemini keys, merge state, etc.) remained in memory, causing stale data to flash if the user logged out and logged back in as a different account.

**Now:** Logout resets all reactive refs to empty/default values and navigates back to the login view, ensuring a clean slate.

## Changes
- `backend/internal/core/store.go`: Logout invalidates all sessions for the user, not just the current token
- `admin/src/App.vue`: Logout clears all reactive state and navigates to login

## Testing
- Verified the code logic matches the Session struct (Token, UserID, CreatedAt, ExpiresAt)
- Confirmed the fix handles edge cases (expired token, already-deleted session)
- Go compilation check skipped (no Go compiler in CI environment)