### PR TITLE
feat(payment): USDT crypto payment gateway webhook (#8)

### DIFF
--- a/backend/internal/core/migrations/006_usdt_webhook_events.sql
+++ b/backend/internal/core/migrations/006_usdt_webhook_events.sql
@@ -1,0 +1,26 @@
+CREATE TABLE IF NOT EXISTS usdt_webhook_events (
+    id text PRIMARY KEY,
+    provider text NOT NULL DEFAULT '',
+    event_type text NOT NULL DEFAULT '',
+    status text NOT NULL DEFAULT 'pending',
+    gateway_id text NOT NULL DEFAULT '',
+    amount_cents bigint NOT NULL DEFAULT 0,
+    currency text NOT NULL DEFAULT 'USD',
+    network text NOT NULL DEFAULT '',
+    tx_hash text NOT NULL DEFAULT '',
+    sender_address text NOT NULL DEFAULT '',
+    receiver_address text NOT NULL DEFAULT '',
+    signature_valid boolean NOT NULL DEFAULT false,
+    raw_payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+    error text NOT NULL DEFAULT '',
+    project_id text NOT NULL DEFAULT '',
+    idempotency_key text NOT NULL DEFAULT '',
+    processed_at timestamptz,
+    received_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS usdt_webhook_events_idempotency_idx ON usdt_webhook_events (idempotency_key) WHERE idempotency_key <> '';
+CREATE INDEX IF NOT EXISTS usdt_webhook_events_status_idx ON usdt_webhook_events (status);
+CREATE INDEX IF NOT EXISTS usdt_webhook_events_gateway_id_idx ON usdt_webhook_events (gateway_id);
+CREATE INDEX IF NOT EXISTS usdt_webhook_events_received_at_idx ON usdt_webhook_events (received_at DESC);
+CREATE INDEX IF NOT EXISTS usdt_webhook_events_project_id_idx ON usdt_webhook_events (project_id);

--- a/backend/internal/core/server.go
+++ b/backend/internal/core/server.go
@@ -840,7 +840,7 @@ func (s *Server) handleUSDTWebhook(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) adminUSDTWebhookEvents(w http.ResponseWriter, r *http.Request) {
-	if _, ok := s.requireUser(w, r); !ok {
+	if _, ok := s.requireAdmin(w, r); !ok {
 		return
 	}
 	events := s.store.ListUSDTWebhookEvents()

--- a/backend/internal/core/server.go
+++ b/backend/internal/core/server.go
@@ -17,10 +17,11 @@ type Server struct {
 	store          *Store
 	payments       *PaymentManager
 	geminiReviewer *GeminiReviewService
+	usdtWebhookHandler *usdtWebhookHandler
 }
 
 func NewServer(cfg Config, store *Store, payments *PaymentManager) *Server {
-	return &Server{cfg: cfg, store: store, payments: payments, geminiReviewer: NewGeminiReviewService(cfg, store)}
+	return &Server{cfg: cfg, store: store, payments: payments, geminiReviewer: NewGeminiReviewService(cfg, store), usdtWebhookHandler: newUSDTWebhookHandler(cfg, store)}
 }
 
 func (s *Server) Routes() http.Handler {
@@ -45,6 +46,8 @@ func (s *Server) Routes() http.Handler {
 	mux.HandleFunc("GET /api/wallets/{address}", s.wallet)
 	mux.HandleFunc("POST /api/wallets/link", s.linkWallet)
 	mux.HandleFunc("POST /api/payments/paypal/orders", s.createPayPalOrder)
+	mux.HandleFunc("POST /api/payments/usdt/webhook", s.handleUSDTWebhook)
+	mux.HandleFunc("GET /api/admin/usdt/webhooks", s.adminUSDTWebhookEvents)
 	mux.HandleFunc("POST /api/uploads", s.uploadAttachment)
 	mux.HandleFunc("GET /api/uploads/", s.downloadAttachment)
 	mux.HandleFunc("GET /api/admin/summary", s.adminSummary)
@@ -830,4 +833,41 @@ func (s *Server) cryptoWebhook(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusCreated, project)
+}
+
+func (s *Server) handleUSDTWebhook(w http.ResponseWriter, r *http.Request) {
+	s.usdtWebhookHandler.handleUSDTWebhook(w, r)
+}
+
+func (s *Server) adminUSDTWebhookEvents(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requireUser(w, r); !ok {
+		return
+	}
+	events := s.store.ListUSDTWebhookEvents()
+
+	// Sanitize: strip raw_payload to prevent leaking gateway secrets
+	sanitized := make([]map[string]interface{}, 0, len(events))
+	for _, e := range events {
+		entry := map[string]interface{}{
+			"id":               e.ID,
+			"provider":         e.Provider,
+			"event_type":       e.EventType,
+			"status":           e.Status,
+			"gateway_id":       e.GatewayID,
+			"amount_cents":     e.AmountCents,
+			"currency":         e.Currency,
+			"network":          e.Network,
+			"tx_hash":          e.TxHash,
+			"sender_address":   e.SenderAddress,
+			"receiver_address": e.ReceiverAddress,
+			"signature_valid":  e.SignatureValid,
+			"project_id":       e.ProjectID,
+			"idempotency_key":  e.IdempotencyKey,
+			"error":            e.Error,
+			"received_at":      e.ReceivedAt,
+			"processed_at":     e.ProcessedAt,
+		}
+		sanitized = append(sanitized, entry)
+	}
+	writeJSON(w, http.StatusOK, sanitized)
 }

--- a/backend/internal/core/store.go
+++ b/backend/internal/core/store.go
@@ -48,6 +48,7 @@ type Store struct {
 	sslReviews        map[string]*SSLReviewStatus
 	geminiAPIKeys     map[string]*GeminiAPIKey
 	geminiWebhookLogs map[string]*GeminiWebhookLog
+	usdtWebhookEvents map[string]*USDTWebhookEvent
 	adminSettings     AdminSettings
 	ledger            []LedgerEntry
 }
@@ -64,6 +65,7 @@ type persistedState struct {
 	SSLReviews        []*SSLReviewStatus  `json:"ssl_reviews"`
 	GeminiAPIKeys     []*GeminiAPIKey     `json:"gemini_api_keys"`
 	GeminiWebhookLogs []*GeminiWebhookLog `json:"gemini_webhook_logs"`
+	USDTWebhookEvents []*USDTWebhookEvent `json:"usdt_webhook_events"`
 	AdminSettings     *AdminSettings      `json:"admin_settings,omitempty"`
 	Ledger            []LedgerEntry       `json:"ledger"`
 }
@@ -91,6 +93,7 @@ func NewStore(cfg Config, payments *PaymentManager, repos RepoFactory, emailer *
 		sslReviews:        map[string]*SSLReviewStatus{},
 		geminiAPIKeys:     map[string]*GeminiAPIKey{},
 		geminiWebhookLogs: map[string]*GeminiWebhookLog{},
+		usdtWebhookEvents: map[string]*USDTWebhookEvent{},
 		adminSettings:     defaultAdminSettings(cfg),
 		ledger:            []LedgerEntry{},
 	}
@@ -1939,4 +1942,65 @@ func (s *Store) IsPaymentReferenceUsed(reference string) bool {
 		}
 	}
 	return false
+}
+
+// SaveUSDTWebhookEvent persists a USDT webhook event.
+func (s *Store) SaveUSDTWebhookEvent(event *USDTWebhookEvent) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.usdtWebhookEvents == nil {
+		s.usdtWebhookEvents = make(map[string]*USDTWebhookEvent)
+	}
+	s.usdtWebhookEvents[event.ID] = event
+}
+
+// FindUSDTWebhookByIdempotencyKey looks up a webhook event by its idempotency key.
+func (s *Store) FindUSDTWebhookByIdempotencyKey(key string) *USDTWebhookEvent {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.usdtWebhookEvents == nil {
+		return nil
+	}
+	for _, event := range s.usdtWebhookEvents {
+		if event.IdempotencyKey == key {
+			return event
+		}
+	}
+	return nil
+}
+
+// ListUSDTWebhookEvents returns all USDT webhook events in reverse chronological order.
+func (s *Store) ListUSDTWebhookEvents() []*USDTWebhookEvent {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	events := make([]*USDTWebhookEvent, 0, len(s.usdtWebhookEvents))
+	for _, event := range s.usdtWebhookEvents {
+		events = append(events, event)
+	}
+	sort.Slice(events, func(i, j int) bool {
+		return events[i].ReceivedAt.After(events[j].ReceivedAt)
+	})
+	return events
+}
+
+// ApplyUSDTWebhookPayment credits a project from a confirmed USDT webhook payment.
+func (s *Store) ApplyUSDTWebhookPayment(event *USDTWebhookEvent) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	project, ok := s.projects[event.ProjectID]
+	if !ok {
+		return fmt.Errorf("project %s not found", event.ProjectID)
+	}
+
+	// Update project payment status
+	project.PaymentStatus = "verified"
+	project.PaymentProvider = "usdt-webhook:" + event.Provider
+	project.PaymentReference = event.TxHash
+
+	// Add ledger entries (mirrors CreateProject ledger logic)
+	clientProjectAccount := "client:" + project.ClientUserID + ":project:" + project.ID
+	s.addLedger("usdt_payment_confirmed", "payment:usdt-webhook", clientProjectAccount, project.BudgetCents, event.TxHash)
+
+	return nil
 }

--- a/backend/internal/core/store.go
+++ b/backend/internal/core/store.go
@@ -1585,7 +1585,8 @@ func (s *Store) snapshotLocked() persistedState {
 		SSLReviews:        make([]*SSLReviewStatus, 0, len(s.sslReviews)),
 		GeminiAPIKeys:     make([]*GeminiAPIKey, 0, len(s.geminiAPIKeys)),
 		GeminiWebhookLogs: make([]*GeminiWebhookLog, 0, len(s.geminiWebhookLogs)),
-		AdminSettings:     cloneAdminSettings(s.adminSettings),
+		USDTWebhookEvents: make([]*USDTWebhookEvent, 0, len(s.usdtWebhookEvents)),
+		AdminSettings: cloneAdminSettings(s.adminSettings),
 		Ledger:            s.ledger,
 	}
 	for _, project := range s.projects {
@@ -1633,6 +1634,13 @@ func (s *Store) snapshotLocked() persistedState {
 	}
 	sort.Slice(state.GeminiWebhookLogs, func(i, j int) bool {
 		return state.GeminiWebhookLogs[i].ReceivedAt.Before(state.GeminiWebhookLogs[j].ReceivedAt)
+	})
+	for _, event := range s.usdtWebhookEvents {
+		eventCopy := *event
+		state.USDTWebhookEvents = append(state.USDTWebhookEvents, &eventCopy)
+	}
+	sort.Slice(state.USDTWebhookEvents, func(i, j int) bool {
+		return state.USDTWebhookEvents[i].ReceivedAt.After(state.USDTWebhookEvents[j].ReceivedAt)
 	})
 	return state
 }
@@ -1945,13 +1953,17 @@ func (s *Store) IsPaymentReferenceUsed(reference string) bool {
 }
 
 // SaveUSDTWebhookEvent persists a USDT webhook event.
-func (s *Store) SaveUSDTWebhookEvent(event *USDTWebhookEvent) {
+func (s *Store) SaveUSDTWebhookEvent(event *USDTWebhookEvent) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.usdtWebhookEvents == nil {
 		s.usdtWebhookEvents = make(map[string]*USDTWebhookEvent)
 	}
 	s.usdtWebhookEvents[event.ID] = event
+	if err := s.saveLocked(); err != nil {
+		return fmt.Errorf("save usdt webhook event: %w", err)
+	}
+	return nil
 }
 
 // FindUSDTWebhookByIdempotencyKey looks up a webhook event by its idempotency key.
@@ -1993,6 +2005,15 @@ func (s *Store) ApplyUSDTWebhookPayment(event *USDTWebhookEvent) error {
 		return fmt.Errorf("project %s not found", event.ProjectID)
 	}
 
+	// Verify the webhook amount matches the project budget
+	if event.AmountCents != project.BudgetCents {
+		return fmt.Errorf("webhook amount %d cents does not match project budget %d cents", event.AmountCents, project.BudgetCents)
+	}
+	// Verify the webhook currency is USDT
+	if event.Currency != "USDT" {
+		return fmt.Errorf("webhook currency %s does not match expected USDT", event.Currency)
+	}
+
 	// Update project payment status
 	project.PaymentStatus = "verified"
 	project.PaymentProvider = "usdt-webhook:" + event.Provider
@@ -2002,5 +2023,8 @@ func (s *Store) ApplyUSDTWebhookPayment(event *USDTWebhookEvent) error {
 	clientProjectAccount := "client:" + project.ClientUserID + ":project:" + project.ID
 	s.addLedger("usdt_payment_confirmed", "payment:usdt-webhook", clientProjectAccount, project.BudgetCents, event.TxHash)
 
+	if err := s.saveLocked(); err != nil {
+		return fmt.Errorf("save usdt payment application: %w", err)
+	}
 	return nil
 }

--- a/backend/internal/core/usdt_webhook.go
+++ b/backend/internal/core/usdt_webhook.go
@@ -1,0 +1,297 @@
+package core
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// USDTWebhookEvent stores a processed crypto payment webhook event.
+type USDTWebhookEvent struct {
+	ID             string          `json:"id"`
+	Provider       string          `json:"provider"`
+	EventType      string          `json:"event_type"`
+	Status         string          `json:"status"`
+	GatewayID      string          `json:"gateway_id"`
+	AmountCents    int64           `json:"amount_cents"`
+	Currency       string          `json:"currency"`
+	Network        string          `json:"network"`
+	TxHash         string          `json:"tx_hash"`
+	SenderAddress  string          `json:"sender_address"`
+	ReceiverAddress string         `json:"receiver_address"`
+	SignatureValid bool            `json:"signature_valid"`
+	RawPayload     json.RawMessage `json:"raw_payload"`
+	Error          string          `json:"error,omitempty"`
+	ProjectID      string          `json:"project_id,omitempty"`
+	IdempotencyKey string          `json:"idempotency_key"`
+	ProcessedAt    *time.Time      `json:"processed_at,omitempty"`
+	ReceivedAt     time.Time       `json:"received_at"`
+}
+
+// USDTWebhookPayload is the expected JSON structure from the crypto gateway.
+type USDTWebhookPayload struct {
+	EventID       string `json:"event_id"`
+	EventType     string `json:"event_type"`
+	GatewayID     string `json:"gateway_id"`
+	IdempotencyKey string `json:"idempotency_key"`
+	Amount        string `json:"amount"`
+	Currency      string `json:"currency"`
+	Network       string `json:"network"`
+	TxHash        string `json:"tx_hash"`
+	Sender        string `json:"sender_address"`
+	Receiver      string `json:"receiver_address"`
+	Status        string `json:"status"`
+	Timestamp     string `json:"timestamp"`
+	Signature     string `json:"signature"`
+	ProjectID     string `json:"project_id,omitempty"`
+}
+
+// USDTWebhookResponse is returned to the gateway after processing.
+type USDTWebhookResponse struct {
+	Received bool   `json:"received"`
+	EventID  string `json:"event_id"`
+	Status   string `json:"status"`
+	Message  string `json:"message,omitempty"`
+}
+
+// usdtWebhookHandler processes incoming USDT payment gateway webhooks.
+type usdtWebhookHandler struct {
+	cfg   Config
+	store *Store
+}
+
+func newUSDTWebhookHandler(cfg Config, store *Store) *usdtWebhookHandler {
+	return &usdtWebhookHandler{cfg: cfg, store: store}
+}
+
+// handleUSDTWebhook handles POST /api/payments/usdt/webhook
+func (h *usdtWebhookHandler) handleUSDTWebhook(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "only POST is accepted")
+		return
+	}
+
+	// Read body for signature verification, then re-decode
+	bodyBytes, err := io.ReadAll(io.LimitReader(r.Body, 1<<20)) // 1 MB limit
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "failed to read request body")
+		return
+	}
+	defer r.Body.Close()
+
+	// Verify signature before any processing
+	signatureHeader := r.Header.Get("X-Webhook-Signature")
+	if err := h.verifySignature(bodyBytes, signatureHeader); err != nil {
+		h.logWebhookEvent(bodyBytes, "", "signature_invalid", "crypto-gateway", err.Error(), "", "")
+		writeError(w, http.StatusUnauthorized, "invalid webhook signature")
+		return
+	}
+
+	var payload USDTWebhookPayload
+	if err := json.Unmarshal(bodyBytes, &payload); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON payload")
+		return
+	}
+
+	// Validate required fields
+	if strings.TrimSpace(payload.EventID) == "" {
+		writeError(w, http.StatusBadRequest, "event_id is required")
+		return
+	}
+	if strings.TrimSpace(payload.IdempotencyKey) == "" {
+		writeError(w, http.StatusBadRequest, "idempotency_key is required")
+		return
+	}
+	if strings.TrimSpace(payload.EventType) == "" {
+		writeError(w, http.StatusBadRequest, "event_type is required")
+		return
+	}
+
+	// Map gateway status to internal payment status
+	internalStatus := mapGatewayStatus(payload.Status)
+	if internalStatus == "" {
+		msg := fmt.Sprintf("unknown gateway status: %s", payload.Status)
+		h.logWebhookEvent(bodyBytes, payload.EventID, "unknown_status", payload.Network, msg, payload.ProjectID, payload.IdempotencyKey)
+		writeError(w, http.StatusBadRequest, msg)
+		return
+	}
+
+	// Idempotency check: if we already processed this idempotency key, return cached result
+	existing := h.store.FindUSDTWebhookByIdempotencyKey(payload.IdempotencyKey)
+	if existing != nil {
+		writeJSON(w, http.StatusOK, USDTWebhookResponse{
+			Received: true,
+			EventID:  existing.ID,
+			Status:   existing.Status,
+			Message:  "duplicate webhook already processed",
+		})
+		return
+	}
+
+	// Parse amount to cents
+	amountCents, err := parseAmountToCents(payload.Amount)
+	if err != nil {
+		h.logWebhookEvent(bodyBytes, payload.EventID, "invalid_amount", payload.Network, err.Error(), payload.ProjectID, payload.IdempotencyKey)
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	now := time.Now().UTC()
+	event := &USDTWebhookEvent{
+		ID:              payload.EventID,
+		Provider:        "crypto-gateway",
+		EventType:       payload.EventType,
+		Status:          internalStatus,
+		GatewayID:       payload.GatewayID,
+		AmountCents:     amountCents,
+		Currency:        strings.ToUpper(strings.TrimSpace(payload.Currency)),
+		Network:         strings.TrimSpace(payload.Network),
+		TxHash:          strings.TrimSpace(payload.TxHash),
+		SenderAddress:   strings.ToLower(strings.TrimSpace(payload.Sender)),
+		ReceiverAddress: strings.ToLower(strings.TrimSpace(payload.Receiver)),
+		SignatureValid:  true,
+		RawPayload:      json.RawMessage(bodyBytes),
+		ProjectID:       strings.TrimSpace(payload.ProjectID),
+		IdempotencyKey:  payload.IdempotencyKey,
+		ProcessedAt:     &now,
+		ReceivedAt:      now,
+	}
+
+	// Verify the receiver matches our configured address
+	if h.cfg.CryptoReceiver != "" && event.ReceiverAddress != "" {
+		configured := strings.TrimPrefix(strings.ToLower(h.cfg.CryptoReceiver), "0x")
+		received := strings.TrimPrefix(event.ReceiverAddress, "0x")
+		if configured != received {
+			event.Status = "receiver_mismatch"
+			event.Error = fmt.Sprintf("receiver %s does not match configured %s", event.ReceiverAddress, h.cfg.CryptoReceiver)
+			h.store.SaveUSDTWebhookEvent(event)
+			writeError(w, http.StatusBadRequest, event.Error)
+			return
+		}
+	}
+
+	// If status is confirmed, update project payment state and mint MRG
+	if event.Status == "confirmed" && event.ProjectID != "" {
+		if err := h.store.ApplyUSDTWebhookPayment(event); err != nil {
+			event.Error = err.Error()
+			event.Status = "apply_failed"
+			h.store.SaveUSDTWebhookEvent(event)
+			writeError(w, http.StatusInternalServerError, "failed to apply payment")
+			return
+		}
+	}
+
+	h.store.SaveUSDTWebhookEvent(event)
+
+	writeJSON(w, http.StatusOK, USDTWebhookResponse{
+		Received: true,
+		EventID:  event.ID,
+		Status:   event.Status,
+		Message:  "webhook processed successfully",
+	})
+}
+
+// verifySignature validates the HMAC-SHA256 webhook signature.
+func (h *usdtWebhookHandler) verifySignature(body []byte, signatureHeader string) error {
+	secret := h.cfg.CryptoWebhookSecret
+	if secret == "" {
+		// In dev mode without a configured secret, skip verification
+		if h.cfg.DevPaymentEnabled {
+			return nil
+		}
+		return fmt.Errorf("CRYPTO_WEBHOOK_SECRET is not configured")
+	}
+
+	if strings.TrimSpace(signatureHeader) == "" {
+		return fmt.Errorf("missing X-Webhook-Signature header")
+	}
+
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	expectedMAC := hex.EncodeToString(mac.Sum(nil))
+
+	// Support both "sha256=<hex>" and bare "<hex>" formats
+	received := strings.TrimPrefix(signatureHeader, "sha256=")
+	received = strings.TrimSpace(received)
+
+	if !hmac.Equal([]byte(strings.ToLower(received)), []byte(strings.ToLower(expectedMAC))) {
+		return fmt.Errorf("webhook signature mismatch")
+	}
+	return nil
+}
+
+// logWebhookEvent records a failed webhook event for debugging.
+func (h *usdtWebhookHandler) logWebhookEvent(raw json.RawMessage, eventID, status, provider, errMsg, projectID, idempotencyKey string) {
+	event := &USDTWebhookEvent{
+		ID:             eventID,
+		Provider:       provider,
+		EventType:      "webhook_callback",
+		Status:         status,
+		RawPayload:     raw,
+		Error:          errMsg,
+		ProjectID:      projectID,
+		IdempotencyKey: idempotencyKey,
+		SignatureValid: status != "signature_invalid",
+		ReceivedAt:     time.Now().UTC(),
+	}
+	h.store.SaveUSDTWebhookEvent(event)
+}
+
+// mapGatewayStatus maps a gateway-specific status to an internal payment status.
+// Supported internal statuses: pending, confirmed, expired, failed, refunded
+func mapGatewayStatus(gatewayStatus string) string {
+	switch strings.ToLower(strings.TrimSpace(gatewayStatus)) {
+	case "pending", "waiting", "processing", "confirming":
+		return "pending"
+	case "confirmed", "completed", "success", "successful", "paid":
+		return "confirmed"
+	case "expired", "timeout", "timed_out":
+		return "expired"
+	case "failed", "error", "rejected", "cancelled", "canceled":
+		return "failed"
+	case "refunded", "reversed":
+		return "refunded"
+	default:
+		return ""
+	}
+}
+
+// parseAmountToCents converts a string amount (e.g. "100.00") to cents.
+func parseAmountToCents(amountStr string) (int64, error) {
+	amountStr = strings.TrimSpace(amountStr)
+	if amountStr == "" {
+		return 0, fmt.Errorf("amount is empty")
+	}
+
+	parts := strings.Split(amountStr, ".")
+	dollarsStr := parts[0]
+	if dollarsStr == "" {
+		dollarsStr = "0"
+	}
+
+	var dollars, cents int64
+	if _, err := fmt.Sscanf(dollarsStr, "%d", &dollars); err != nil {
+		return 0, fmt.Errorf("invalid dollar amount: %q", amountStr)
+	}
+
+	if len(parts) > 1 {
+		fraction := parts[1]
+		if len(fraction) > 2 {
+			fraction = fraction[:2]
+		}
+		for len(fraction) < 2 {
+			fraction += "0"
+		}
+		if _, err := fmt.Sscanf(fraction, "%d", &cents); err != nil {
+			return 0, fmt.Errorf("invalid cent amount: %q", amountStr)
+		}
+	}
+
+	return dollars*100 + cents, nil
+}

--- a/backend/internal/core/usdt_webhook.go
+++ b/backend/internal/core/usdt_webhook.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -170,7 +171,9 @@ func (h *usdtWebhookHandler) handleUSDTWebhook(w http.ResponseWriter, r *http.Re
 		if configured != received {
 			event.Status = "receiver_mismatch"
 			event.Error = fmt.Sprintf("receiver %s does not match configured %s", event.ReceiverAddress, h.cfg.CryptoReceiver)
-			h.store.SaveUSDTWebhookEvent(event)
+			if err := h.store.SaveUSDTWebhookEvent(event); err != nil {
+				log.Printf("failed to save receiver_mismatch webhook event: %v", err)
+			}
 			writeError(w, http.StatusBadRequest, event.Error)
 			return
 		}
@@ -181,13 +184,17 @@ func (h *usdtWebhookHandler) handleUSDTWebhook(w http.ResponseWriter, r *http.Re
 		if err := h.store.ApplyUSDTWebhookPayment(event); err != nil {
 			event.Error = err.Error()
 			event.Status = "apply_failed"
-			h.store.SaveUSDTWebhookEvent(event)
+			if saveErr := h.store.SaveUSDTWebhookEvent(event); saveErr != nil {
+				log.Printf("failed to save apply_failed webhook event: %v", saveErr)
+			}
 			writeError(w, http.StatusInternalServerError, "failed to apply payment")
 			return
 		}
 	}
 
-	h.store.SaveUSDTWebhookEvent(event)
+	if err := h.store.SaveUSDTWebhookEvent(event); err != nil {
+		log.Printf("failed to save webhook event %s: %v", event.ID, err)
+	}
 
 	writeJSON(w, http.StatusOK, USDTWebhookResponse{
 		Received: true,
@@ -240,7 +247,9 @@ func (h *usdtWebhookHandler) logWebhookEvent(raw json.RawMessage, eventID, statu
 		SignatureValid: status != "signature_invalid",
 		ReceivedAt:     time.Now().UTC(),
 	}
-	h.store.SaveUSDTWebhookEvent(event)
+	if err := h.store.SaveUSDTWebhookEvent(event); err != nil {
+		log.Printf("failed to save log webhook event: %v", err)
+	}
 }
 
 // mapGatewayStatus maps a gateway-specific status to an internal payment status.

--- a/backend/internal/core/usdt_webhook_test.go
+++ b/backend/internal/core/usdt_webhook_test.go
@@ -1,0 +1,324 @@
+package core
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMapGatewayStatus(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"pending", "pending"},
+		{"waiting", "pending"},
+		{"processing", "pending"},
+		{"confirming", "pending"},
+		{"confirmed", "confirmed"},
+		{"completed", "confirmed"},
+		{"success", "confirmed"},
+		{"paid", "confirmed"},
+		{"expired", "expired"},
+		{"timeout", "expired"},
+		{"failed", "failed"},
+		{"error", "failed"},
+		{"cancelled", "failed"},
+		{"refunded", "refunded"},
+		{"reversed", "refunded"},
+		{"unknown_status", ""},
+	}
+
+	for _, tc := range tests {
+		got := mapGatewayStatus(tc.input)
+		if got != tc.expected {
+			t.Errorf("mapGatewayStatus(%q) = %q, want %q", tc.input, got, tc.expected)
+		}
+	}
+}
+
+func TestParseAmountToCents(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected int64
+		hasError bool
+	}{
+		{"100.00", 10000, false},
+		{"50.50", 5050, false},
+		{"1.99", 199, false},
+		{"0.01", 1, false},
+		{"1000", 100000, false},
+		{"0", 0, false},
+		{"", 0, true},
+		{"abc", 0, true},
+	}
+
+	for _, tc := range tests {
+		got, err := parseAmountToCents(tc.input)
+		if tc.hasError && err == nil {
+			t.Errorf("parseAmountToCents(%q): expected error, got none", tc.input)
+		}
+		if !tc.hasError && err != nil {
+			t.Errorf("parseAmountToCents(%q): unexpected error: %v", tc.input, err)
+		}
+		if got != tc.expected {
+			t.Errorf("parseAmountToCents(%q) = %d, want %d", tc.input, got, tc.expected)
+		}
+	}
+}
+
+func TestVerifySignature(t *testing.T) {
+	secret := "test-webhook-secret"
+	cfg := Config{
+		CryptoWebhookSecret: secret,
+		DevPaymentEnabled: false,
+	}
+	h := &usdtWebhookHandler{cfg: cfg}
+
+	body := []byte(`{"event_id":"evt_123","event_type":"payment.confirmed"}`)
+
+	// Correct signature
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	correctSig := hex.EncodeToString(mac.Sum(nil))
+
+	if err := h.verifySignature(body, "sha256="+correctSig); err != nil {
+		t.Errorf("correct signature should pass: %v", err)
+	}
+	if err := h.verifySignature(body, correctSig); err != nil {
+		t.Errorf("bare hex signature should pass: %v", err)
+	}
+
+	// Wrong signature
+	if err := h.verifySignature(body, "sha256=badsignature"); err == nil {
+		t.Error("wrong signature should fail")
+	}
+
+	// Missing signature
+	if err := h.verifySignature(body, ""); err == nil {
+		t.Error("missing signature should fail")
+	}
+}
+
+func TestVerifySignatureDevMode(t *testing.T) {
+	cfg := Config{
+		CryptoWebhookSecret: "",
+		DevPaymentEnabled: true,
+	}
+	h := &usdtWebhookHandler{cfg: cfg}
+
+	body := []byte(`{"event_id":"evt_123"}`)
+	// In dev mode with no secret, signature check should pass
+	if err := h.verifySignature(body, ""); err != nil {
+		t.Errorf("dev mode should skip signature verification: %v", err)
+	}
+}
+
+func TestUSDTWebhookHandler_BadMethod(t *testing.T) {
+	cfg := Config{DevPaymentEnabled: true}
+	store := newTestStore(t, cfg)
+	h := newUSDTWebhookHandler(cfg, store)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/payments/usdt/webhook", nil)
+	w := httptest.NewRecorder()
+	h.handleUSDTWebhook(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestUSDTWebhookHandler_MissingSignature(t *testing.T) {
+	cfg := Config{
+		CryptoWebhookSecret: "secret123",
+		DevPaymentEnabled: false,
+	}
+	store := newTestStore(t, cfg)
+	h := newUSDTWebhookHandler(cfg, store)
+
+	body := []byte(`{"event_id":"evt_1"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/payments/usdt/webhook", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.handleUSDTWebhook(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 for missing signature, got %d", w.Code)
+	}
+}
+
+func TestUSDTWebhookHandler_InvalidJSON(t *testing.T) {
+	cfg := Config{DevPaymentEnabled: true}
+	store := newTestStore(t, cfg)
+	h := newUSDTWebhookHandler(cfg, store)
+
+	body := []byte(`not json`)
+	req := httptest.NewRequest(http.MethodPost, "/api/payments/usdt/webhook", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.handleUSDTWebhook(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for invalid JSON, got %d", w.Code)
+	}
+}
+
+func TestUSDTWebhookHandler_MissingEventID(t *testing.T) {
+	cfg := Config{DevPaymentEnabled: true}
+	store := newTestStore(t, cfg)
+	h := newUSDTWebhookHandler(cfg, store)
+
+	payload := USDTWebhookPayload{
+		IdempotencyKey: "idem_1",
+		EventType:      "payment.confirmed",
+		Status:         "confirmed",
+	}
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest(http.MethodPost, "/api/payments/usdt/webhook", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.handleUSDTWebhook(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for missing event_id, got %d", w.Code)
+	}
+}
+
+func TestUSDTWebhookHandler_ValidConfirmed(t *testing.T) {
+	cfg := Config{
+		DevPaymentEnabled: true,
+		TokenSymbol:       "MRG",
+		PlatformFeeBps:    1000,
+		CryptoReceiver:    "0xabc123",
+	}
+	store := newTestStore(t, cfg)
+	h := newUSDTWebhookHandler(cfg, store)
+
+	payload := USDTWebhookPayload{
+		EventID:        "evt_confirmed_1",
+		EventType:      "payment.confirmed",
+		IdempotencyKey: "idem_confirmed_1",
+		Amount:         "100.00",
+		Currency:       "USD",
+		Network:        "ethereum",
+		TxHash:         "0xabc",
+		Sender:         "0xsender",
+		Receiver:       "0xabc123",
+		Status:         "confirmed",
+	}
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest(http.MethodPost, "/api/payments/usdt/webhook", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.handleUSDTWebhook(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp USDTWebhookResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if !resp.Received {
+		t.Error("expected Received=true")
+	}
+	if resp.Status != "confirmed" {
+		t.Errorf("expected status confirmed, got %s", resp.Status)
+	}
+}
+
+func TestUSDTWebhookHandler_ReceiverMismatch(t *testing.T) {
+	cfg := Config{
+		DevPaymentEnabled: true,
+		CryptoReceiver:    "0xexpected",
+	}
+	store := newTestStore(t, cfg)
+	h := newUSDTWebhookHandler(cfg, store)
+
+	payload := USDTWebhookPayload{
+		EventID:        "evt_mismatch",
+		EventType:      "payment.confirmed",
+		IdempotencyKey: "idem_mismatch_1",
+		Amount:         "100.00",
+		Currency:       "USD",
+		Network:        "ethereum",
+		Receiver:       "0xwrong",
+		Status:         "confirmed",
+	}
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest(http.MethodPost, "/api/payments/usdt/webhook", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.handleUSDTWebhook(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for receiver mismatch, got %d", w.Code)
+	}
+}
+
+func TestUSDTWebhookHandler_IdempotencyDuplicate(t *testing.T) {
+	cfg := Config{
+		DevPaymentEnabled: true,
+		CryptoReceiver:    "0xabc123",
+	}
+	store := newTestStore(t, cfg)
+	h := newUSDTWebhookHandler(cfg, store)
+
+	// First request
+	payload := USDTWebhookPayload{
+		EventID:        "evt_dup",
+		EventType:      "payment.confirmed",
+		IdempotencyKey: "idem_dup_1",
+		Amount:         "50.00",
+		Currency:       "USD",
+		Network:        "ethereum",
+		Receiver:       "0xabc123",
+		Status:         "confirmed",
+	}
+	body1, _ := json.Marshal(payload)
+	req1 := httptest.NewRequest(http.MethodPost, "/api/payments/usdt/webhook", bytes.NewReader(body1))
+	req1.Header.Set("Content-Type", "application/json")
+	w1 := httptest.NewRecorder()
+	h.handleUSDTWebhook(w1, req1)
+
+	if w1.Code != http.StatusOK {
+		t.Fatalf("first request: expected 200, got %d", w1.Code)
+	}
+
+	// Duplicate request with same idempotency key
+	payload2 := payload
+	payload2.EventID = "evt_dup_2"
+	body2, _ := json.Marshal(payload2)
+	req2 := httptest.NewRequest(http.MethodPost, "/api/payments/usdt/webhook", bytes.NewReader(body2))
+	req2.Header.Set("Content-Type", "application/json")
+	w2 := httptest.NewRecorder()
+	h.handleUSDTWebhook(w2, req2)
+
+	if w2.Code != http.StatusOK {
+		t.Fatalf("duplicate request: expected 200, got %d", w2.Code)
+	}
+
+	var resp USDTWebhookResponse
+	if err := json.Unmarshal(w2.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if resp.Message != "duplicate webhook already processed" {
+		t.Errorf("expected duplicate message, got: %s", resp.Message)
+	}
+}
+
+// newTestStore creates a minimal in-memory store for webhook tests.
+func newTestStore(t *testing.T, cfg Config) *Store {
+	t.Helper()
+	store, err := NewStore(cfg, NewPaymentManager(cfg), nil, NewEmailSender(cfg))
+	if err != nil {
+		t.Fatalf("failed to create test store: %v", err)
+	}
+	return store
+}

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -2514,6 +2514,7 @@ const fundingAmountOptions = [
 const paymentMethodOptions = [
   { label: 'Credit / Debit card', caption: 'Visa, Mastercard, Amex', icon: CreditCard },
   { label: 'USDC', caption: 'Ethereum, Polygon, Arbitrum', icon: CircleDollarSign },
+  { label: 'USDT', caption: 'Tether on Ethereum, Tron, Polygon', icon: CircleDollarSign },
   { label: 'Bank transfer', caption: 'Worldwide bank transfer', icon: FileCheck2 },
   { label: 'PayPal', caption: 'Fast and secure', icon: CreditCard },
 ];
@@ -4143,7 +4144,8 @@ function shortLedgerReference(value = '') {
 }
 
 function paymentMethodForProject() {
-  return projectPaymentMethod.value === 'USDC' ? 'crypto' : 'paypal';
+  if (projectPaymentMethod.value === 'USDC' || projectPaymentMethod.value === 'USDT') return 'crypto';
+	return 'paypal';
 }
 
 function paymentReferenceForProject() {


### PR DESCRIPTION
## Bounty #8 — USDT Crypto Payment Gateway Webhook

### Implementation Summary

Implements a complete USDT payment intake flow with server webhook callback, signature verification, and proof ledger integration.

### Changes

**Backend (Go):**
- `POST /api/payments/usdt/webhook` — Gateway callback endpoint
- `GET /api/admin/usdt/webhooks` — Admin listing (sanitized, no raw_payload/secrets)
- HMAC-SHA256 signature verification via `X-Webhook-Signature` header
- Idempotency: duplicate `idempotency_key` returns cached result, no duplicate ledger entries
- Gateway status mapping: pending → confirmed → expired → failed → refunded
- Receiver address verification against `CRYPTO_RECEIVER`
- Project payment state + ledger entry updates on confirmed payment
- Provider abstraction (`crypto-gateway`) for future gateway additions
- Database migration `006_usdt_webhook_events.sql` with proper indexes

**Frontend (Vue):**
- Added USDT payment method option to payment choice grid
- USDT maps to `crypto` payment method in project creation

### Sandbox/Test Configuration

Environment variables:
- `CRYPTO_WEBHOOK_SECRET` — HMAC key for signature verification
- `CRYPTO_RECEIVER` — Expected USDT receiver address
- `CRYPTO_RPC_URL` — EVM RPC endpoint (existing, for on-chain verification)
- Dev mode: signature check skipped when no secret configured and `DEV_PAYMENT_ENABLED=true`

### Test Results

```
=== 11 new tests, all PASS ===
TestMapGatewayStatus          — 15 gateway status mappings
TestParseAmountToCents        — 8 amount parsing cases
TestVerifySignature           — HMAC-SHA256 correct/wrong/missing
TestVerifySignatureDevMode    — Dev mode bypass
TestUSDTWebhookHandler_BadMethod
TestUSDTWebhookHandler_MissingSignature
TestUSDTWebhookHandler_InvalidJSON
TestUSDTWebhookHandler_MissingEventID
TestUSDTWebhookHandler_ValidConfirmed
TestUSDTWebhookHandler_ReceiverMismatch
TestUSDTWebhookHandler_IdempotencyDuplicate
```

All existing tests continue to pass (full suite: PASS).

### Idempotency & Safety

- Duplicate webhooks with the same `idempotency_key` are detected and return the cached result — no duplicate token minting or ledger entries
- Invalid signatures return 401 Unauthorized
- Receiver mismatch returns 400 Bad Request
- Raw webhook payloads stored for audit but excluded from admin API (no secret leakage)
- Ledger entries are hash-chained (existing mechanism)

### Gateway Provider

Currently implements a generic `crypto-gateway` provider abstraction. The payload schema (`USDTWebhookPayload`) supports standard fields: `event_id`, `event_type`, `gateway_id`, `idempotency_key`, `amount`, `currency`, `network`, `tx_hash`, `sender_address`, `receiver_address`, `status`, `signature`.

This can integrate with any USDT payment gateway that posts webhook callbacks with HMAC-SHA256 signatures.

Fixes #8