### PR TITLE
fix(frontend): reset authenticated views on logout

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -4418,7 +4418,7 @@ function clearSession() {
   authReturnToProjectWizard.value = false;
   removeStoredToken();
 
-  if (publicPage.value === 'dashboard' || projectWizardVisible.value) {
+  if (!publicModeVisible.value || projectWizardVisible.value) {
     projectWizardVisible.value = false;
     openPublicPage('home');
   }

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -4414,7 +4414,14 @@ function clearSession() {
   dashboardNotificationsError.value = '';
   dashboardError.value = '';
   selectedDashboardProjectID.value = '';
+  pendingProjectPaymentAfterAuth.value = false;
+  authReturnToProjectWizard.value = false;
   removeStoredToken();
+
+  if (publicPage.value === 'dashboard' || projectWizardVisible.value) {
+    projectWizardVisible.value = false;
+    openPublicPage('home');
+  }
 }
 
 async function submitAuth() {


### PR DESCRIPTION
## Summary
- Clear pending auth/project-payment flags during logout cleanup.
- If logout happens from the authenticated dashboard or project wizard, return the user to the public home page instead of leaving stale authenticated UI visible.
- Preserve existing best-effort backend logout call and local token removal.

## Bounty
- Issue: #20 ([200 MRG] Fix logout bug)
- Type: bug bounty
- Expected reward: 200 MRG

## Evidence / tests
- `npm --prefix frontend test -- --run`
- Result: 8/8 passing.

## Notes
- Small frontend-only cleanup; no env or migration changes.
- Visual evidence not captured in this headless run, but the patch targets the stale authenticated-screen state after logout.