### PR TITLE
fix: reset logout state and route to public home (#20)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -4479,7 +4479,11 @@ function clearSession() {
   dashboardNotifications.value = [];
   dashboardNotificationsError.value = '';
   dashboardError.value = '';
+  dashboardSearch.value = '';
   selectedDashboardProjectID.value = '';
+  pendingProjectPaymentAfterAuth.value = false;
+  authReturnToProjectWizard.value = false;
+  errorMessage.value = '';
   removeStoredToken();
 }
 
@@ -4535,8 +4539,11 @@ async function restoreSession() {
 async function logout() {
   try {
     await api('/api/auth/logout', { method: 'POST', body: JSON.stringify({}) });
+  } catch {
+    // Still clear local session if the API is unreachable.
   } finally {
     clearSession();
+    openPublicPage('home', { replace: true, scroll: false });
     showToast('Logged out.');
   }
 }


### PR DESCRIPTION
Fixes #20

## Problem
After logout, dashboard UI state could remain visible because `clearSession()` did not reset search/pending auth flags and `logout()` did not return to the public shell.

## Fix
- Reset `dashboardSearch`, pending auth flags, and `errorMessage` in `clearSession()`
- Call `openPublicPage('home', { replace: true, scroll: false })` after logout
- Clear local session when `/api/auth/logout` fails

## vs other open PRs
- Unlike #42/#28: also clears dashboard search + pending auth state
- Unlike #55/#40: does not navigate inside `clearSession()` (safe for expired-token restore)
- Unlike #67: uses `openPublicPage()` instead of duplicating manual history/state updates

## Verification
- `npm test` (8/8)
- `npm run build:local`

/attempt #20