### PR TITLE
[200 MRG] Fix logout bug

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -4537,6 +4537,9 @@ async function logout() {
     await api('/api/auth/logout', { method: 'POST', body: JSON.stringify({}) });
   } finally {
     clearSession();
+    publicModeVisible.value = true;
+    publicPage.value = 'home';
+    updatePublicBrowserPath('home', true);
     showToast('Logged out.');
   }
 }


### PR DESCRIPTION
## Summary

Fix the logout bug that leaves users on a blank screen after logging out.

## Bug Analysis

When a logged-in user clicks logout:
1. `logout()` calls `clearSession()` which clears `token.value` and `user.value`
2. But `publicModeVisible` remains `false`
3. The template renders neither the dashboard (`user && !publicModeVisible` fails) nor the public page (`publicModeVisible` is still `false`)
4. User sees a blank/empty screen

## Fix

**File:** `frontend/src/App.vue` (3 lines added)

After `clearSession()` in the `logout()` function, added:
- `publicModeVisible.value = true`
- `publicPage.value = 'home'`
- `updatePublicBrowserPath('home', true)` — updates browser URL to home

## Evidence

### Before
```
User clicks logout → blank screen (no dashboard, no public page)
```

### After
```
User clicks logout → public home page loads smoothly with 'Logged out.' toast
```

### Testing
- `npm test`: ✓ (existing tests pass — no regressions)
- Desktop viewport: ✓ Verified logout navigates to home
- Mobile viewport: ✓ Works correctly

## Claim
Claimed in issue #1: [comment link](https://github.com/mergeos-bounties/mergeos/issues/1#issuecomment-4557106645)

Related to #20