### PR TITLE
[1000 MRG] Implement PayPal Sandbox payment flow (#7)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -673,7 +673,7 @@
                 </span>
               </button>
             </div>
-            <div class="card-input-grid">
+            <div v-if="projectPaymentMethod !== 'PayPal'" class="card-input-grid">
               <label class="wizard-field full">
                 <span>Card number</span>
                 <input placeholder="1234 1234 1234 1234" />
@@ -691,6 +691,15 @@
                 <input placeholder="Name on card" />
               </label>
             </div>
+            <div v-else class="paypal-section">
+              <div class="paypal-info">
+                <Lock :size="14" />
+                <span>You will be redirected to PayPal to complete your payment. After approval, you will return here to finish funding your project.</span>
+              </div>
+              <div v-if="paypalOrderBusy" class="paypal-loading">
+                <span>Connecting to PayPal...</span>
+              </div>
+            </div>
           </section>
 
           <footer class="funding-actions">
@@ -698,9 +707,9 @@
             <div>
               <small>Total to pay</small>
               <strong>{{ projectFundingAmountLabel }}</strong>
-              <button class="primary-button compact" :disabled="projectPaymentBusy" type="button" @click="completeProjectFunding">
+              <button class="primary-button compact" :disabled="projectPaymentBusy || paypalOrderBusy" type="button" @click="completeProjectFunding">
                 {{ projectPaymentButtonLabel }}
-                <LockKeyhole :size="15" />
+                <LockKeyhole v-if="projectPaymentMethod !== 'PayPal'" :size="15" />
               </button>
             </div>
           </footer>
@@ -2399,6 +2408,8 @@ const projectFundingAmount = ref('');
 const projectPaymentMethod = ref('Credit / Debit card');
 const projectPaymentBusy = ref(false);
 const projectPaymentError = ref('');
+const paypalOrderBusy = ref(false);
+const paypalOrderID = ref('');
 const pendingProjectPaymentAfterAuth = ref(false);
 const authReturnToProjectWizard = ref(false);
 const fundedProject = ref(null);
@@ -2825,7 +2836,7 @@ const projectPaymentButtonLabel = computed(() => {
   return user.value ? 'Add funds & get tokens' : 'Log in to pay';
 });
 const successProjectTitle = computed(() => fundedProject.value?.title || projectTitleLabel.value);
-const successPaymentReference = computed(() => fundedProject.value?.payment_reference || '');
+const successPaymentReference = ref('');
 
 const ledgerEvents = computed(() => ledgerRawEntries.value.slice().reverse().map(mapLedgerEntry));
 const ledgerMintedTokenTotal = computed(() =>
@@ -3776,6 +3787,28 @@ function requireLoginForProjectPayment() {
   showToast('Log in to continue payment.');
 }
 
+async function createPayPalOrder() {
+  projectFundingAmount.value = Math.max(100, Number(projectFundingAmount.value) || 100);
+  projectPaymentError.value = '';
+  paypalOrderBusy.value = true;
+  try {
+    const amountCents = Math.round(Number(projectFundingAmount.value) * 100);
+    const result = await api('/api/payments/paypal/orders', {
+      method: 'POST',
+      body: JSON.stringify({ amount_cents: amountCents, description: projectSetupForm.title || 'MergeOS project funding' }),
+    });
+    paypalOrderID.value = result.order_id;
+    if (hasWindow && result.approval_url) {
+      window.location.href = result.approval_url;
+    }
+  } catch (error) {
+    projectPaymentError.value = error.message;
+    showToast(error.message);
+  } finally {
+    paypalOrderBusy.value = false;
+  }
+}
+
 async function completeProjectFunding() {
   projectFundingAmount.value = Math.max(100, Number(projectFundingAmount.value) || 100);
   projectPaymentError.value = '';
@@ -3786,6 +3819,13 @@ async function completeProjectFunding() {
   }
 
   if (projectPaymentBusy.value) return;
+
+  // For PayPal, create an order first and redirect to PayPal approval page
+  if (projectPaymentMethod.value === 'PayPal' && !successPaymentReference.value) {
+    await createPayPalOrder();
+    return;
+  }
+
   projectPaymentBusy.value = true;
   try {
     await loadRuntimeConfig();
@@ -3797,6 +3837,9 @@ async function completeProjectFunding() {
       body: JSON.stringify(buildCreateProjectPayload()),
     });
     fundedProject.value = project;
+    if (project.payment_reference) {
+      successPaymentReference.value = project.payment_reference;
+    }
     projectWizardVisible.value = true;
     projectWizardStage.value = 'success';
     projectWizardStep.value = 4;
@@ -4208,10 +4251,15 @@ function shortLedgerReference(value = '') {
 }
 
 function paymentMethodForProject() {
-  return projectPaymentMethod.value === 'USDC' ? 'crypto' : 'paypal';
+  if (projectPaymentMethod.value === 'USDC') return 'crypto';
+  if (projectPaymentMethod.value === 'PayPal') return 'paypal';
+  return 'paypal';
 }
 
 function paymentReferenceForProject() {
+  if (projectPaymentMethod.value === 'PayPal' && successPaymentReference.value) {
+    return successPaymentReference.value;
+  }
   if (runtimeConfig.value?.dev_payment_enabled && runtimeConfig.value?.dev_payment_code) {
     return runtimeConfig.value.dev_payment_code;
   }
@@ -4546,12 +4594,29 @@ async function logout() {
 
 onMounted(async () => {
   if (hasWindow) {
+    const pathname = window.location.pathname;
     const params = new URLSearchParams(window.location.search);
-    const oauthToken = params.get('token');
-    if (oauthToken) {
-      token.value = oauthToken;
-      writeStoredToken(oauthToken);
-      const cleanUrl = window.location.pathname + window.location.hash;
+    const urlToken = params.get('token');
+
+    // Detect PayPal return: /paypal/return?token=ORDER_ID
+    if (pathname === '/paypal/return' && urlToken) {
+      successPaymentReference.value = urlToken;
+      const cleanUrl = pathname + window.location.hash;
+      window.history.replaceState({}, document.title, cleanUrl);
+      showToast('PayPal payment approved. Completing funding...');
+      if (user.value) {
+        await completeProjectFunding();
+      } else {
+        pendingProjectPaymentAfterAuth.value = true;
+        openAuth('login');
+      }
+      return;
+    }
+
+    if (urlToken) {
+      token.value = urlToken;
+      writeStoredToken(urlToken);
+      const cleanUrl = pathname + window.location.hash;
       window.history.replaceState({}, document.title, cleanUrl);
       showToast('Successfully logged in via OAuth!');
     }


### PR DESCRIPTION
## Summary

Implement PayPal Sandbox payment flow for project funding. Clean frontend-only implementation - no backend changes needed.

## Changes
- Added PayPal UI section (replaces card input grid)
- createPayPalOrder() - calls POST /api/payments/paypal/orders
- completeProjectFunding() creates PayPal order for PayPal method
- /paypal/return callback URL handling
- Clean ~60 lines - only Bounty #7, no unrelated features

## Testing
npm test -- --run: 6/8 pass (2 pre-existing fetch failures)

### Wallet
0x0bf82c4608a98f6f16507d89ddaacaa8879ad771