### PR TITLE
[2000 MRG] Frontend homepage responsive QA and layout breakage check (#11)

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -8221,3 +8221,1195 @@ svg {
     grid-template-columns: 1fr;
   }
 }
+
+/* ── Homepage Responsive QA — comprehensive viewport coverage ── */
+
+/* 1024px — iPad Pro / small laptop */
+@media (max-width: 1024px) {
+  .nav-links {
+    gap: 14px;
+  }
+
+  .brand-link {
+    min-width: 100px;
+  }
+
+  .brand-link strong {
+    font-size: 17px;
+  }
+
+  .hero-section {
+    grid-template-columns: minmax(290px, 0.82fr) minmax(400px, 1.18fr);
+    gap: 24px;
+  }
+
+  .hero-copy h1 {
+    font-size: 42px;
+  }
+
+  .hero-copy p {
+    font-size: 15px;
+  }
+
+  .public-home-hero,
+  .public-info-hero {
+    grid-template-columns: minmax(0, 1fr) minmax(280px, 360px);
+    gap: 20px;
+  }
+
+  .public-home-copy h1 {
+    font-size: 46px;
+  }
+
+  .public-talent-strip {
+    grid-template-columns: minmax(0, 1fr) minmax(300px, 1fr);
+  }
+
+  .public-talent-strip h2 {
+    font-size: 24px;
+  }
+
+  .public-workflow-grid {
+    gap: 12px;
+  }
+
+  .ledger-table-wrap {
+    overflow-x: auto;
+  }
+
+  .marketplace-project-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px;
+  }
+
+  .auth-modal {
+    width: min(900px, 100%);
+  }
+
+  .dashboard-shell {
+    grid-template-columns: 160px minmax(0, 1fr);
+  }
+
+  .dash-topbar {
+    grid-template-columns: minmax(160px, 220px) minmax(0, 1fr) auto;
+  }
+
+  .dash-topnav {
+    gap: 10px;
+  }
+
+  .dash-content {
+    grid-template-columns: minmax(0, 1fr) 240px;
+    padding: 12px;
+  }
+
+  .dash-overview-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .feature-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 10px;
+  }
+
+  .stats-strip {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+/* 820px — iPad Air portrait pivot */
+@media (max-width: 820px) {
+  .nav-links {
+    gap: 10px;
+  }
+
+  .nav-links a,
+  .nav-links button {
+    font-size: 12px;
+    padding: 6px 0;
+  }
+
+  .brand-link strong {
+    font-size: 16px;
+  }
+
+  .public-home-hero,
+  .public-info-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .public-home-panel,
+  .public-info-summary {
+    max-width: 480px;
+  }
+
+  .marketplace-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .marketplace-visual {
+    min-height: 320px;
+  }
+
+  .marketplace-project-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .auth-modal {
+    width: min(720px, 100%);
+  }
+}
+
+/* 430px — iPhone 14 Pro Max */
+@media (max-width: 430px) {
+  .nav-inner {
+    min-height: 56px;
+  }
+
+  .nav-links,
+  .locale-button {
+    display: none;
+  }
+
+  .brand-link {
+    min-width: auto;
+  }
+
+  .brand-link strong {
+    font-size: 16px;
+  }
+
+  .nav-actions .secondary-button.compact {
+    padding: 0 10px;
+    font-size: 12px;
+  }
+
+  .nav-actions .primary-button.compact {
+    padding: 0 10px;
+    font-size: 12px;
+  }
+
+  .nav-actions .primary-button.compact svg {
+    display: none;
+  }
+
+  .hero-section {
+    grid-template-columns: 1fr;
+    padding-top: 24px;
+    gap: 20px;
+  }
+
+  .hero-copy h1 {
+    font-size: 36px;
+  }
+
+  .hero-copy p {
+    font-size: 14px;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .hero-actions .primary-button,
+  .hero-actions .secondary-button {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .trust-chips span {
+    flex: 1 1 140px;
+    font-size: 11px;
+    padding: 0 8px;
+  }
+
+  .public-home-page,
+  .public-info-page,
+  .marketplace-page,
+  .ledger-page {
+    padding: 16px 0 24px;
+  }
+
+  .public-home-copy h1,
+  .public-info-hero h1 {
+    font-size: 36px;
+  }
+
+  .public-home-copy p,
+  .public-info-hero p {
+    font-size: 15px;
+  }
+
+  .public-home-panel,
+  .public-info-summary {
+    padding: 16px;
+  }
+
+  .public-stat-grid strong {
+    font-size: 20px;
+  }
+
+  .public-workflow-grid {
+    grid-template-columns: 1fr;
+    gap: 10px;
+  }
+
+  .public-talent-strip {
+    grid-template-columns: 1fr;
+    gap: 16px;
+    padding: 18px 0;
+  }
+
+  .public-talent-strip h2 {
+    font-size: 22px;
+  }
+
+  .public-talent-strip p {
+    font-size: 14px;
+  }
+
+  .public-talent-list article {
+    padding: 10px;
+  }
+
+  .public-talent-list strong {
+    font-size: 13px;
+  }
+
+  .feature-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+  }
+
+  .feature-card {
+    padding: 14px;
+  }
+
+  .feature-icon {
+    width: 28px;
+    height: 28px;
+    margin-bottom: 12px;
+  }
+
+  .feature-card h3 {
+    font-size: 12px;
+  }
+
+  .feature-card p {
+    font-size: 11px;
+  }
+
+  .stats-strip {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .stats-strip article {
+    min-height: 60px;
+    padding: 10px;
+  }
+
+  .stats-strip article + article {
+    border-left: 0;
+  }
+
+  .stats-strip article:nth-child(-n + 2) {
+    border-top: 0;
+  }
+
+  .stats-strip strong {
+    font-size: 17px;
+  }
+
+  .how-hero-copy h1 {
+    font-size: 32px;
+  }
+
+  .how-hero-copy p {
+    font-size: 13px;
+  }
+
+  .how-steps-panel {
+    grid-template-columns: repeat(5, minmax(110px, 1fr));
+    padding: 16px 10px 14px;
+  }
+
+  .workflow-board {
+    grid-template-columns: 1fr;
+  }
+
+  .how-cta {
+    align-items: stretch;
+    flex-direction: column;
+    padding: 16px;
+  }
+
+  .how-cta h2 {
+    font-size: 17px;
+  }
+
+  .how-cta-actions {
+    width: 100%;
+    justify-content: stretch;
+  }
+
+  .how-cta-actions button {
+    flex: 1;
+  }
+
+  .marketplace-copy h1 {
+    font-size: 36px;
+  }
+
+  .marketplace-actions {
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .marketplace-actions .primary-button,
+  .marketplace-actions .secondary-button {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .marketplace-trust {
+    grid-template-columns: 1fr;
+  }
+
+  .marketplace-visual {
+    min-height: 320px;
+  }
+
+  .talent-preview-card {
+    left: 10px;
+    top: 28px;
+    width: 190px;
+    padding: 12px;
+  }
+
+  .market-code-card {
+    right: 10px;
+    top: 20px;
+    width: 160px;
+    padding: 12px;
+  }
+
+  .agent-preview-card {
+    left: 10px;
+    bottom: 14px;
+    width: 190px;
+    padding: 12px;
+  }
+
+  .marketplace-selects {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .marketplace-selects button {
+    font-size: 12px;
+    padding: 8px 10px;
+  }
+
+  .marketplace-project-grid {
+    grid-template-columns: 1fr;
+    gap: 10px;
+  }
+
+  .marketplace-benefit-strip {
+    grid-template-columns: 1fr;
+  }
+
+  .marketplace-benefit-strip article {
+    padding: 14px;
+  }
+
+  .contributor-list article {
+    padding: 10px;
+  }
+
+  .ledger-hero {
+    grid-template-columns: 1fr;
+    gap: 18px;
+  }
+
+  .ledger-title-row h1 {
+    font-size: 34px;
+  }
+
+  .ledger-trust-row {
+    grid-template-columns: 1fr;
+  }
+
+  .ledger-content {
+    grid-template-columns: 1fr;
+  }
+
+  .ledger-table thead {
+    display: none;
+  }
+
+  .ledger-table tbody tr {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 6px;
+    padding: 12px 10px;
+  }
+
+  .ledger-table td {
+    padding: 4px;
+    font-size: 12px;
+  }
+
+  .ledger-table td:first-child {
+    grid-column: 1 / -1;
+  }
+
+  .ledger-footer-stats {
+    grid-template-columns: 1fr;
+  }
+
+  .modal-backdrop {
+    padding: 10px;
+  }
+
+  .auth-modal {
+    max-height: calc(100vh - 20px);
+    border-radius: 12px;
+  }
+
+  .auth-modal-main {
+    padding: 24px 14px 18px;
+    gap: 20px;
+  }
+
+  .auth-copy {
+    margin-top: 20px;
+  }
+
+  .auth-copy h2 {
+    font-size: 24px;
+  }
+
+  .auth-copy p {
+    font-size: 13px;
+  }
+
+  .auth-close-button {
+    top: 12px;
+    right: 12px;
+  }
+
+  .auth-close-button svg {
+    width: 20px;
+    height: 20px;
+  }
+
+  .social-auth-row {
+    grid-template-columns: 1fr;
+    gap: 8px;
+    margin-top: 18px;
+  }
+
+  .social-auth-row button {
+    justify-content: center;
+    font-size: 13px;
+    padding: 10px;
+  }
+
+  .auth-field {
+    gap: 4px;
+  }
+
+  .auth-field .input-shell {
+    padding: 8px 10px;
+  }
+
+  .auth-field .input-shell input {
+    font-size: 13px;
+  }
+
+  .auth-field .input-shell svg {
+    width: 16px;
+    height: 16px;
+  }
+
+  .auth-option-row {
+    gap: 8px;
+    margin-top: 14px;
+    font-size: 12px;
+  }
+
+  .primary-button.large,
+  .secondary-button.large {
+    padding: 10px 18px;
+    font-size: 13px;
+  }
+
+  .toast {
+    left: 10px;
+    right: 10px;
+    top: 70px;
+    font-size: 13px;
+    padding: 10px 14px;
+  }
+
+  .project-flow-shell .project-flow-navbar {
+    padding: 0 10px;
+  }
+
+  .project-flow-nav {
+    display: none;
+  }
+
+  .project-flow-sidebar {
+    display: none;
+  }
+
+  .project-flow-main {
+    grid-template-columns: 1fr;
+  }
+
+  .dash-topbar {
+    grid-template-columns: 1fr;
+  }
+
+  .dash-top-actions {
+    justify-content: space-between;
+  }
+
+  .dash-sidebar {
+    display: none;
+  }
+
+  .dash-content {
+    grid-template-columns: 1fr;
+    padding: 10px;
+  }
+
+  .dash-rail {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* 390px — iPhone 14 / 13 */
+@media (max-width: 390px) {
+  :root {
+    --page-gutter: 12px;
+  }
+
+  .hero-copy h1 {
+    font-size: 30px;
+  }
+
+  .hero-copy p {
+    font-size: 13px;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+  }
+
+  .hero-actions .primary-button,
+  .hero-actions .secondary-button {
+    flex: 1;
+    width: 100%;
+    justify-content: center;
+  }
+
+  .public-home-copy h1,
+  .public-info-hero h1,
+  .marketplace-copy h1,
+  .ledger-title-row h1 {
+    font-size: 30px;
+  }
+
+  .public-home-copy p,
+  .public-info-hero p,
+  .marketplace-copy p {
+    font-size: 14px;
+  }
+
+  .public-home-panel,
+  .public-info-summary {
+    padding: 12px;
+  }
+
+  .public-stat-grid strong {
+    font-size: 18px;
+  }
+
+  .public-stat-grid span {
+    font-size: 11px;
+  }
+
+  .public-talent-strip h2 {
+    font-size: 20px;
+  }
+
+  .public-workflow-grid strong {
+    font-size: 14px;
+  }
+
+  .public-workflow-grid p {
+    font-size: 12px;
+  }
+
+  .feature-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .stats-strip {
+    grid-template-columns: 1fr;
+  }
+
+  .stats-strip article {
+    border-top: 1px solid #eef0f2;
+  }
+
+  .stats-strip article:first-child {
+    border-top: 0;
+  }
+
+  .how-hero-copy h1 {
+    font-size: 28px;
+  }
+
+  .how-steps-panel {
+    grid-template-columns: repeat(5, minmax(88px, 1fr));
+    padding: 12px 8px 10px;
+    gap: 8px;
+  }
+
+  .how-hero-step {
+    gap: 6px;
+    padding: 6px;
+  }
+
+  .how-hero-step strong {
+    font-size: 11px;
+  }
+
+  .how-hero-step small {
+    font-size: 10px;
+  }
+
+  .marketplace-copy h1 {
+    font-size: 30px;
+  }
+
+  .marketplace-visual {
+    min-height: 280px;
+  }
+
+  .talent-preview-card {
+    width: 160px;
+    left: 8px;
+    top: 24px;
+    padding: 10px;
+  }
+
+  .talent-card-top {
+    gap: 6px;
+  }
+
+  .talent-card-top small {
+    font-size: 9px;
+  }
+
+  .talent-preview-card strong {
+    font-size: 11px;
+  }
+
+  .talent-card-bottom strong {
+    font-size: 13px;
+  }
+
+  .market-code-card {
+    width: 140px;
+    right: 8px;
+    top: 18px;
+    padding: 10px;
+  }
+
+  .market-code-card code {
+    font-size: 9px;
+  }
+
+  .agent-preview-card {
+    width: 170px;
+    left: 8px;
+    bottom: 12px;
+    padding: 10px;
+  }
+
+  .agent-preview-card strong {
+    font-size: 12px;
+  }
+
+  .agent-preview-card p {
+    font-size: 10px;
+  }
+
+  .marketplace-selects {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .marketplace-selects .more-filter-button {
+    grid-column: 1 / -1;
+  }
+
+  .marketplace-categories {
+    overflow-x: auto;
+    gap: 6px;
+    padding-bottom: 6px;
+  }
+
+  .marketplace-categories button {
+    white-space: nowrap;
+    font-size: 12px;
+    padding: 6px 10px;
+  }
+
+  .auth-copy h2 {
+    font-size: 22px;
+  }
+
+  .social-auth-row button {
+    font-size: 12px;
+    padding: 8px;
+  }
+
+  .auth-brand {
+    font-size: 16px;
+  }
+
+  .auth-brand-mark {
+    width: 28px;
+    height: 28px;
+  }
+
+  .auth-security-note {
+    font-size: 11px;
+    padding: 10px;
+  }
+
+  .auth-switch-line {
+    font-size: 13px;
+  }
+
+  .how-cta h2 {
+    font-size: 16px;
+  }
+
+  .how-cta p {
+    font-size: 12px;
+  }
+
+  .primary-button.large,
+  .secondary-button.large {
+    padding: 8px 14px;
+    font-size: 12px;
+  }
+
+  .project-flow-navbar .nav-actions .secondary-button.compact {
+    padding: 0 8px;
+    font-size: 11px;
+  }
+
+  .project-flow-navbar .nav-actions .primary-button.compact {
+    padding: 0 8px;
+    font-size: 11px;
+  }
+
+  .ledger-table tbody tr {
+    padding: 10px 8px;
+    gap: 4px;
+  }
+
+  .ledger-table td {
+    font-size: 11px;
+  }
+
+  .ledger-card-head h2 {
+    font-size: 15px;
+  }
+
+  .ledger-live-grid strong {
+    font-size: 18px;
+  }
+
+  .ledger-live-grid span {
+    font-size: 10px;
+  }
+
+  .modal-backdrop {
+    padding: 6px;
+  }
+
+  .auth-modal {
+    border-radius: 10px;
+  }
+
+  .auth-modal-main {
+    padding: 18px 10px 14px;
+    gap: 14px;
+  }
+
+  .dash-content {
+    padding: 8px;
+  }
+
+  .dash-overview-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .dash-project-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .dash-project-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .dash-project-actions button {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
+/* 360px — Small Android devices */
+@media (max-width: 360px) {
+  :root {
+    --page-gutter: 8px;
+  }
+
+  body {
+    min-width: 320px;
+  }
+
+  .nav-inner {
+    min-height: 50px;
+    gap: 8px;
+  }
+
+  .brand-link {
+    gap: 5px;
+  }
+
+  .brand-mark {
+    width: 28px;
+    height: 28px;
+  }
+
+  .brand-link strong {
+    font-size: 14px;
+  }
+
+  .nav-actions {
+    gap: 6px;
+  }
+
+  .nav-actions .secondary-button.compact,
+  .nav-actions .primary-button.compact {
+    padding: 0 6px;
+    font-size: 11px;
+    min-height: 30px;
+  }
+
+  .nav-actions .primary-button.compact svg,
+  .header .nav-actions .primary-button.compact svg {
+    display: none;
+  }
+
+  .hero-copy h1 {
+    font-size: 26px;
+  }
+
+  .hero-copy p {
+    font-size: 13px;
+  }
+
+  .hero-pill {
+    font-size: 10px;
+    padding: 5px 8px;
+  }
+
+  .trust-chips span {
+    flex: 1 1 120px;
+    font-size: 10px;
+    padding: 0 6px;
+    min-height: 28px;
+  }
+
+  .public-home-copy h1,
+  .public-info-hero h1,
+  .marketplace-copy h1,
+  .ledger-title-row h1 {
+    font-size: 26px;
+  }
+
+  .public-home-copy p,
+  .public-info-hero p,
+  .marketplace-copy p {
+    font-size: 13px;
+  }
+
+  .public-home-panel,
+  .public-info-summary {
+    padding: 10px;
+  }
+
+  .public-stat-grid {
+    gap: 10px;
+  }
+
+  .public-stat-grid strong {
+    font-size: 16px;
+  }
+
+  .public-workflow-grid {
+    gap: 8px;
+  }
+
+  .public-workflow-grid button {
+    padding: 12px;
+  }
+
+  .public-workflow-grid strong {
+    font-size: 13px;
+  }
+
+  .public-workflow-grid p {
+    font-size: 11px;
+  }
+
+  .public-talent-strip h2 {
+    font-size: 18px;
+  }
+
+  .how-hero-copy h1 {
+    font-size: 25px;
+  }
+
+  .how-steps-panel {
+    grid-template-columns: repeat(5, minmax(78px, 1fr));
+    padding: 10px 6px 8px;
+    gap: 6px;
+  }
+
+  .how-hero-step {
+    gap: 4px;
+    padding: 4px;
+  }
+
+  .how-hero-step strong {
+    font-size: 10px;
+  }
+
+  .how-hero-step small {
+    font-size: 9px;
+  }
+
+  .how-hero-step span {
+    width: 20px;
+    height: 20px;
+    font-size: 10px;
+  }
+
+  .how-hero-step span svg {
+    width: 12px;
+    height: 12px;
+  }
+
+  .how-cta {
+    padding: 14px;
+  }
+
+  .how-cta h2 {
+    font-size: 15px;
+  }
+
+  .marketplace-visual {
+    min-height: 240px;
+  }
+
+  .talent-preview-card {
+    width: 140px;
+    left: 6px;
+    top: 20px;
+    padding: 8px;
+  }
+
+  .talent-card-top small {
+    font-size: 8px;
+  }
+
+  .talent-preview-card strong {
+    font-size: 10px;
+  }
+
+  .mini-tags span {
+    font-size: 8px;
+    padding: 2px 5px;
+  }
+
+  .talent-card-bottom strong {
+    font-size: 12px;
+  }
+
+  .talent-card-bottom span {
+    font-size: 9px;
+  }
+
+  .market-code-card {
+    width: 120px;
+    right: 6px;
+    top: 14px;
+    padding: 8px;
+  }
+
+  .market-code-card code {
+    font-size: 8px;
+  }
+
+  .agent-preview-card {
+    width: 150px;
+    left: 6px;
+    bottom: 10px;
+    padding: 8px;
+  }
+
+  .agent-preview-card strong {
+    font-size: 11px;
+  }
+
+  .agent-preview-card p {
+    font-size: 9px;
+  }
+
+  .agent-icon {
+    width: 24px;
+    height: 24px;
+  }
+
+  .agent-icon svg {
+    width: 14px;
+    height: 14px;
+  }
+
+  .marketplace-selects {
+    grid-template-columns: 1fr;
+  }
+
+  .marketplace-copy h1 {
+    font-size: 26px;
+  }
+
+  .project-card-top span:first-child svg {
+    width: 20px;
+    height: 20px;
+  }
+
+  .project-money-row strong {
+    font-size: 14px;
+  }
+
+  .project-client-row {
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .project-tag-row {
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  .project-tag-row span {
+    font-size: 10px;
+    padding: 2px 6px;
+  }
+
+  .ledger-tabs {
+    overflow-x: auto;
+    gap: 8px;
+    padding-bottom: 4px;
+  }
+
+  .ledger-tabs button {
+    white-space: nowrap;
+    font-size: 11px;
+    padding: 6px 10px;
+  }
+
+  .ledger-table-actions button {
+    font-size: 11px;
+    padding: 6px 8px;
+  }
+
+  .ledger-table tbody tr {
+    padding: 8px 6px;
+    gap: 3px;
+  }
+
+  .ledger-table td {
+    font-size: 10px;
+  }
+
+  .auth-modal-main {
+    padding: 14px 8px 12px;
+    gap: 12px;
+  }
+
+  .auth-copy h2 {
+    font-size: 20px;
+  }
+
+  .social-auth-row button {
+    font-size: 11px;
+    padding: 6px;
+  }
+
+  .auth-field .input-shell {
+    padding: 6px 8px;
+  }
+
+  .auth-field .input-shell input {
+    font-size: 12px;
+  }
+
+  .dash-content {
+    padding: 6px;
+  }
+
+  .dash-pr-row {
+    grid-template-columns: 28px minmax(0, 1fr) auto;
+    gap: 6px;
+    padding: 10px;
+  }
+
+  .dash-project-title h2 {
+    font-size: 16px;
+  }
+
+  .dash-metrics {
+    grid-template-columns: 1fr;
+  }
+
+  .dash-metrics article {
+    padding: 10px;
+  }
+
+  .public-home-page,
+  .public-info-page,
+  .marketplace-page,
+  .ledger-page {
+    padding: 10px 0 20px;
+  }
+
+  .home-container {
+    padding-left: var(--page-gutter);
+    padding-right: var(--page-gutter);
+  }
+}


### PR DESCRIPTION
## Summary

Comprehensive responsive QA pass across 8 viewports (1440px to 360px). Pure CSS - no template or JS changes.

## Changes
- Navbar: hamburger-visible breakpoint lowered, compact logo/text on small screens
- Hero: Grid/text/image responsive at all breakpoints
- Feature Grid & Stats Strip: single column on mobile
- Marketplace: 2 col -> 1 col at 820px, card padding/text sizing
- Ledger: Card-style table rows on mobile (replaces horizontal scroll)
- Auth Modal: full-width on mobile, no overflow
- Dashboard, Project Flow Wizard & Toast: safe at all tested viewports

## Viewports
1440px, 1366px, 1024px, 820px, 768px, 430px, 390px, 360px

## Testing
npm test -- --run: 7/8 pass (1 pre-existing fetch failure)

### Wallet
0x0bf82c4608a98f6f16507d89ddaacaa8879ad771