### PR TITLE
fix(nav): show login button on mobile viewports under 760px (#13)

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -6261,9 +6261,11 @@ svg {
     min-width: auto;
   }
 
-  .nav-actions .secondary-button {
-    display: none;
-  }
+ .nav-actions .secondary-button {
+ padding: 0 10px;
+ font-size: 12px;
+ min-height: 34px;
+ }
 
   .hero-copy h1 {
     font-size: 40px;


### PR DESCRIPTION
## Fix: Login button hidden on mobile

The @media (max-width: 760px) media query hides .secondary-button inside .nav-actions with display: none, making Log in invisible on mobile.

**Fix:** Replace display: none with compact sizing:
- padding: 0 10px (was 15px)
- font-size: 12px (was 13px)  
- min-height: 34px (was 38px)

| Viewport | Before | After |
|----------|:---:|:---:|
| 375px | ❌ hidden | ✅ visible |
| 430px | ❌ hidden | ✅ visible |

Fixes #13

Wallet: 0x0bf82c4608a98f6f16507d89ddaacaa8879ad771