### PR TITLE
feat: improve create-project flow with clear project type split (#12)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -127,7 +127,7 @@
           <div v-if="projectWizardStep === 1" class="wizard-form-grid">
             <label class="wizard-field full">
               <span>Project title <b>*</b></span>
-              <input v-model.trim="projectSetupForm.title" placeholder="Enter a clear project title" />
+              <input v-model.trim="projectSetupForm.title" :placeholder="projectSetupForm.projectType === 'Bug Fix' ? 'Briefly describe the bug you need fixed' : 'Enter a clear project title'" />
             </label>
 
             <label class="wizard-field full">
@@ -136,7 +136,7 @@
                 v-model.trim="projectSetupForm.shortDescription"
                 rows="5"
                 maxlength="1000"
-                placeholder="Describe your project, what you want to build, and the problem you're solving..."
+                :placeholder="projectSetupForm.projectType === 'Bug Fix' ? 'Describe the bug, expected behavior, and how to reproduce it' : 'Describe your project, what you want to build, and the problem you are solving...'"
               />
               <small>{{ projectSetupForm.shortDescription.length }} / 1000</small>
             </label>
@@ -146,32 +146,33 @@
                 <strong>Project type <b>*</b></strong>
                 <small>What kind of work do you need?</small>
               </div>
-              <div class="project-type-grid">
+              <div class="project-type-grid project-type-split">
                 <button
                   v-for="type in projectTypeOptions"
                   :key="type.label"
                   :class="{ selected: projectSetupForm.projectType === type.label }"
-                  class="select-tile"
+                  class="select-tile select-tile-big"
                   type="button"
                   @click="projectSetupForm.projectType = type.label"
                 >
-                  <component :is="type.icon" :size="18" />
+                  <component :is="type.icon" :size="24" />
                   <strong>{{ type.label }}</strong>
                   <small>{{ type.caption }}</small>
-                  <CheckCircle2 v-if="projectSetupForm.projectType === type.label" class="tile-check" :size="16" />
+                  <CheckCircle2 v-if="projectSetupForm.projectType === type.label" class="tile-check" :size="20" />
                 </button>
               </div>
             </section>
 
             <label class="wizard-field full">
               <span>Tech stack <small>(optional)</small></span>
-              <input v-model.trim="projectSetupForm.techStack" placeholder="Add technologies or frameworks" />
+              <input v-model.trim="projectSetupForm.techStack"
+                :placeholder="projectSetupForm.projectType === 'Bug Fix' ? 'Technologies used in the existing project' : 'Add technologies or frameworks'" />
             </label>
 
-            <section class="wizard-section full attach-repo">
+            <section v-if="projectSetupForm.projectType === 'Bug Fix'" class="wizard-section full attach-repo">
               <div class="attach-repo-head">
                 <div>
-                  <strong>Attach repository <small>(optional)</small></strong>
+                  <strong>Attach repository <b>*</b></strong>
                   <p>Load open issues and turn them into scored fix tasks.</p>
                 </div>
                 <button class="secondary-button compact" :disabled="repoImportBusy" type="button" @click="loadRepoIssues">
@@ -200,6 +201,12 @@
                     <small>Score {{ issue.score }} · {{ issue.complexity }} · {{ formatMRGFromCents(issue.estimated_cents) }}</small>
                   </div>
                 </article>
+              </div>
+            </section>
+
+            <section v-if="projectSetupForm.projectType === 'New Project'" class="wizard-section full">
+              <div class="new-project-hint">
+                <p>Describe your idea below — we will help you scope it, price it, and find the right contributor.</p>
               </div>
             </section>
           </div>
@@ -2501,12 +2508,8 @@ const projectSetupSteps = [
 ];
 
 const projectTypeOptions = [
-  { label: 'Web Development', caption: 'Web apps', icon: Globe2 },
-  { label: 'Repo Issue Fix', caption: 'Existing repo', icon: Bug },
-  { label: 'Mobile Development', caption: 'iOS and Android', icon: Compass },
-  { label: 'AI / ML', caption: 'Agents and models', icon: Bot },
-  { label: 'Smart Contract', caption: 'Web3', icon: Link2 },
-  { label: 'Other', caption: 'Custom work', icon: MoreHorizontal },
+  { label: 'New Project', caption: 'Brand-new project or idea from scratch', icon: Sparkles },
+  { label: 'Bug Fix', caption: 'Fix an issue in an existing repository', icon: Bug },
 ];
 
 const budgetTypeOptions = [
@@ -3703,6 +3706,7 @@ function buildPriceEvaluationPayload() {
     deliverables: visibleDeliverables.value,
     timeline: projectTimelineLabel.value,
     tech_stack: projectSetupForm.techStack,
+      projectType: projectSetupForm.projectType,
     complexity: projectSetupForm.allowAgents ? 'moderate' : 'high',
     constraints: projectSetupForm.skills,
     reference_budget_cents: centsFromMRG(projectSetupForm.budgetAmount),

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -702,6 +702,36 @@ svg {
   grid-template-columns: repeat(5, minmax(104px, 1fr));
 }
 
+.project-type-split {
+  grid-template-columns: repeat(2, minmax(200px, 1fr)) !important;
+  max-width: 520px;
+}
+
+.select-tile-big {
+  min-height: 110px !important;
+  padding: 18px 20px !important;
+  gap: 10px !important;
+}
+
+.select-tile-big strong {
+  font-size: 15px !important;
+  font-weight: 920 !important;
+}
+
+.select-tile-big small {
+  font-size: 12px !important;
+}
+
+.new-project-hint {
+  padding: 12px 0;
+}
+
+.new-project-hint p {
+  color: #6b7280;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
 .budget-type-grid {
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }


### PR DESCRIPTION
## Summary

Replaced the 6-category project type grid (Web Development, Mobile, AI/ML, etc.) with two clear options:

1. **New Project** - brand-new project or idea that needs work from scratch
2. **Bug Fix** - fix an issue in an existing repository

## Changes

### frontend/src/App.vue
- Updated `projectTypeOptions` to two objects: 'New Project' and 'Bug Fix'
- Made project type tiles bigger (2-column layout, 110px height, larger font)
- Tech stack placeholder changes based on selected type
- Attach repository section shows only when 'Bug Fix' is selected
- Added new-project hint text when 'New Project' is selected
- Added `projectType` to submission payload
- Updated placeholder text for title and description based on type

### frontend/src/styles.css
- Added `.project-type-split` (2-column grid, max-width 520px)
- Added `.select-tile-big` (larger tiles, bigger text)
- Added `.new-project-hint` styles

## Evidence

(Add screenshots here after testing)

Closes #12