### PR TITLE
fix: login/logout modal responsive behavior (#13)

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -6261,7 +6261,19 @@ svg {
     min-width: auto;
   }
 
+  /*
+   * Bounty #13 fix: previously every .secondary-button inside .nav-actions was
+   * hidden at <=760px. That removed the only entry point to the login modal
+   * ("Log in") and the logout button on mobile, leaving signed-in users unable
+   * to log out and guests unable to open the auth modal from the navbar.
+   * Keep buttons visible but compact them so they fit on narrow viewports.
+   */
   .nav-actions .secondary-button {
+    padding: 0 12px;
+    font-size: 12px;
+  }
+
+  .nav-actions .user-pill {
     display: none;
   }
 
@@ -6322,7 +6334,17 @@ svg {
     flex: 1 1 auto;
   }
 
+  /*
+   * Bounty #13 fix: the dashboard profile / logout button was display:none on
+   * mobile, leaving signed-in users unable to log out from the dashboard top
+   * bar. Shrink it instead of hiding it.
+   */
   .dash-profile {
+    padding: 0 10px;
+    font-size: 12px;
+  }
+
+  .dash-profile small {
     display: none;
   }
 
@@ -6402,6 +6424,33 @@ svg {
 }
 
 @media (max-width: 520px) {
+  /* Bounty #13: tighten auth modal padding/sizing on very small viewports
+     so the modal does not clip its close button or controls. */
+  .modal-backdrop {
+    padding: 10px;
+  }
+
+  .auth-modal {
+    max-height: calc(100vh - 20px);
+    border-radius: 12px;
+  }
+
+  .auth-modal-main {
+    padding: 26px 16px 20px;
+    gap: 22px;
+  }
+
+  .auth-copy h2 {
+    font-size: 24px;
+  }
+
+  .auth-close-button {
+    top: 10px;
+    right: 10px;
+    width: 36px;
+    height: 36px;
+  }
+
   .primary-button.compact {
     padding: 0 12px;
   }


### PR DESCRIPTION
# fix: login/logout modal responsive behavior (#13)

Closes #13.

## Root cause

Two `@media (max-width: 760px)` rules in `frontend/src/styles.css` were
catastrophically aggressive — they used `display: none` to remove the
auth entry points from the navbar and the logout affordance from the
dashboard on mobile. Combined with a few padding values that were never
tightened below 760px, this left the auth/session UX broken on every
mobile viewport listed in the bounty scope (430px, 390px, 360px).

| Issue | Where | Why it broke |
|---|---|---|
| "Log in" button vanishes on mobile | `.nav-actions .secondary-button { display: none; }` inside `@media (max-width: 760px)` | The only entry point to the login modal from the public navbar is `.secondary-button.compact` — hiding *every* secondary button hides "Log in" and the navbar "Logout". |
| Navbar "Logout" vanishes on mobile | same rule as above | Signed-in users could not log out from the navbar on mobile. |
| Dashboard profile / logout pill hidden on mobile | `.dash-profile { display: none; }` inside `@media (max-width: 760px)` | The dashboard top bar had no other logout affordance on mobile. |
| Auth modal cramped / close button overlapping brand on <=430px | `.modal-backdrop` padding stayed at the mobile fallback of `16px` and `.auth-modal-main` padding stayed at `30px 20px 24px`; close button at `top:16px right:16px` could overlap the `.auth-brand` mark at very narrow widths | No `@media (max-width: 520px)` overrides existed for the modal. |

## Fix

Single-file change: `frontend/src/styles.css`.

1. At `<=760px`: keep `.nav-actions .secondary-button` visible. Compact
   it (`padding: 0 12px; font-size: 12px;`) so "Log in" / "Sign up" /
   "Logout" all fit. Hide the `.user-pill` (the email string) instead,
   since that is decorative and the longest element in the nav.
2. At `<=760px`: stop hiding `.dash-profile`. Compact it and hide its
   `<small>` line so the avatar + logout chevron remains tappable.
3. At `<=520px`: add modal-specific overrides — tighter backdrop
   padding (`10px`), tighter `.auth-modal-main` padding
   (`26px 16px 20px`), `max-height: calc(100vh - 20px)`, smaller close
   button (`36x36` at `top/right: 10px`), and smaller `.auth-copy h2`
   (`24px`) so the modal fits 360-430px viewports without clipping.

## Before / after per breakpoint

| Viewport | Before | After |
|---|---|---|
| 1280px desktop | Two-column modal (form + benefits aside) — OK. | Unchanged. |
| 1024px laptop | Two-column modal — OK. | Unchanged. |
| 768px tablet | Single-column (980px breakpoint hides `.auth-benefit-panel`) — OK. | Unchanged. |
| 430px mobile | "Log in" missing from nav; signed-in users have no logout button; modal usable if opened via deep link. | "Log in" + "Logout" visible in nav; dashboard logout pill visible; modal usable. |
| 390px mobile | Same as 430px; social buttons stack via existing `760px` rule. | Same fixes apply; social buttons still stack. |
| 360px mobile | Same as 430px; modal close button visually overlaps brand mark. | Auth entry points restored; close button repositioned via new `<=520px` block; backdrop tighter so the modal has room to breathe. |

## Manual verification

- `npm install` in `frontend/`.
- `npm run build:local` — passes (vite build, both client + SSR
  bundles emit cleanly).
- DevTools device emulation at 1440 / 1280 / 1024 / 768 / 430 / 390 /
  360 px on the public home page and dashboard:
  - "Log in" button reachable on mobile, opens modal.
  - "Sign up" button still reachable on mobile.
  - Logout reachable on mobile from both navbar (`/`) and dashboard.
  - Modal close button (Escape and click) works at every breakpoint.
  - No horizontal overflow at any tested width.
  - Social buttons stack vertically on `<=760px` (existing behavior).

## Files changed

- `frontend/src/styles.css` — three localized changes inside existing
  `@media (max-width: 760px)` block and one new `@media (max-width: 520px)`
  block targeting the auth modal only. No JS / template changes.
