### PR TITLE
fix: login modal responsive - show secondary button on mobile (#13)

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -6261,7 +6261,24 @@ svg {
     min-width: auto;
   }
 
-  .nav-actions .secondary-button {
+  .nav-actions {
+    min-width: 0;
+  }
+
+  .nav-actions .secondary-button,
+  .nav-actions .primary-button.compact {
+    font-size: 13px;
+    padding: 0 10px;
+    min-height: 34px;
+  }
+
+  .user-pill {
+    max-width: 100px;
+    font-size: 12px;
+    padding: 0 8px;
+  }
+
+  .nav-actions .primary-button.compact svg {
     display: none;
   }
 
@@ -6279,7 +6296,9 @@ svg {
 
   .hero-actions .primary-button,
   .hero-actions .secondary-button {
-    flex: 1 1 220px;
+    flex: 1 1 180px;
+    font-size: 14px;
+    padding: 0 12px;
   }
 
   .console-grid,
@@ -6369,7 +6388,8 @@ svg {
   }
 
   .auth-modal-main {
-    padding: 30px 20px 24px;
+    padding: 24px 16px 20px;
+    gap: 20px;
   }
 
   .auth-close-button {
@@ -6378,15 +6398,15 @@ svg {
   }
 
   .auth-copy {
-    margin-top: 28px;
+    margin-top: 20px;
   }
 
   .auth-copy h2 {
-    font-size: 28px;
+    font-size: 24px;
   }
 
   .auth-copy p {
-    font-size: 14px;
+    font-size: 13px;
   }
 
   .social-auth-row {


### PR DESCRIPTION
## Summary

Fix login modal responsive behavior on viewports <760px. The **Log in** button was hidden on mobile via \display: none\ on \.nav-actions .secondary-button\, making authentication impossible on phone-sized screens.

## Key Changes

| Location | Before | After |
|---|---|---|
| \.nav-actions .secondary-button\ (mobile) | \display: none\ | Visible with compact sizing (13px, 34px min-height, 10px padding) |
| \.nav-actions\ (mobile) | \min-width: 290px\ causing overflow | \min-width: 0\ — fits naturally |
| Auth modal padding (mobile) | \30px 20px 24px\ | \24px 16px 20px\ with reduced gap (20px) |
| Auth modal heading (mobile) | 28px | 24px |
| Auth copy description (mobile) | 14px | 13px |
| Hero actions buttons (mobile) | \lex: 1 1 220px\ | \lex: 1 1 180px\, 14px font |
| Primary button SVG icons (mobile) | Visible, taking horizontal space | Hidden to save layout room |
| User pill (mobile) | Full width | \max-width: 100px\, 12px font |

## Evidence

**Before:** Log in button hidden on mobile via \display: none\
**After:** Log in and Sign up buttons visible with compact sizing that fits small viewports

### Viewport testing:

| Viewport | Login button | Signup button | Modal | Build |
|---|---|---|---|---|
| 375px (iPhone) | ✅ Visible | ✅ Visible | ✅ Scrolls properly | ✅ Pass |
| 430px (iPhone Pro) | ✅ Visible | ✅ Visible | ✅ Responsive | ✅ Pass |
| 768px (iPad) | ✅ No regression | ✅ No regression | ✅ Grid layout | ✅ Pass |
| 1440px (Desktop) | ✅ No regression | ✅ No regression | ✅ Full layout | ✅ Pass |

## Bounty

**Bounty:** #13 (500 MRG)
**Wallet (Solana):** \HUFz3mnXkSDzfxfRgiKsZ6w5zgfcwShigHrYGxvgrjAF\

## PR Scope

This PR is scoped *only* to the login modal responsive fix for #13. No unrelated files, CI changes, or evidence images included.