### PR TITLE
feat: add hamburger mobile navigation for responsive homepage (fixes #11)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1382,6 +1382,21 @@
           <a href="/ledger" :class="{ 'nav-active': publicPage === 'ledger' }" @click.prevent="openPublicPage('ledger')">Ledger Logs</a>
         </nav>
 
+        <button class="hamburger-button" type="button" aria-label="Toggle navigation" :aria-expanded="mobileMenuOpen" @click="mobileMenuOpen = !mobileMenuOpen">
+          <svg v-if="!mobileMenuOpen" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><line x1="4" y1="6" x2="20" y2="6"/><line x1="4" y1="12" x2="20" y2="12"/><line x1="4" y1="18" x2="20" y2="18"/></svg>
+          <svg v-else width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><line x1="6" y1="6" x2="18" y2="18"/><line x1="18" y1="6" x2="6" y2="18"/></svg>
+        </button>
+
+        <!-- Mobile nav overlay -->
+        <div v-if="mobileMenuOpen" class="mobile-nav-overlay" @click="mobileMenuOpen = false"></div>
+        <nav v-if="mobileMenuOpen" class="mobile-nav-panel" aria-label="Mobile navigation">
+          <a href="/product" @click.prevent="mobileMenuOpen = false; openPublicPage('product')">Product <ChevronDown :size="13" /></a>
+          <a href="/solutions" @click.prevent="mobileMenuOpen = false; openPublicPage('solutions')">Solutions <ChevronDown :size="13" /></a>
+          <a href="/marketplace" @click.prevent="mobileMenuOpen = false; openPublicPage('marketplace')">Marketplace</a>
+          <a href="/how-it-works" @click.prevent="mobileMenuOpen = false; openPublicPage('how-it-works')">How it works</a>
+          <a href="/ledger" @click.prevent="mobileMenuOpen = false; openPublicPage('ledger')">Ledger Logs</a>
+        </nav>
+
         <div class="nav-actions">
           <template v-if="user">
             <button class="secondary-button compact" type="button" @click="openDashboard">Dashboard</button>
@@ -2380,6 +2395,7 @@ const authBusy = ref(false);
 const authRememberMe = ref(false);
 const authTermsAccepted = ref(true);
 const errorMessage = ref('');
+const mobileMenuOpen = ref(false);
 const showPassword = ref(false);
 const showConfirmPassword = ref(false);
 const toastMessage = ref('');

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1382,19 +1382,25 @@
           <a href="/ledger" :class="{ 'nav-active': publicPage === 'ledger' }" @click.prevent="openPublicPage('ledger')">Ledger Logs</a>
         </nav>
 
-        <button class="hamburger-button" type="button" aria-label="Toggle navigation" :aria-expanded="mobileMenuOpen" @click="mobileMenuOpen = !mobileMenuOpen">
-          <svg v-if="!mobileMenuOpen" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><line x1="4" y1="6" x2="20" y2="6"/><line x1="4" y1="12" x2="20" y2="12"/><line x1="4" y1="18" x2="20" y2="18"/></svg>
-          <svg v-else width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><line x1="6" y1="6" x2="18" y2="18"/><line x1="18" y1="6" x2="6" y2="18"/></svg>
+        <button
+          class="hamburger-button"
+          type="button"
+          :aria-label="mobileMenuOpen ? 'Close navigation' : 'Open navigation'"
+          :aria-expanded="mobileMenuOpen"
+          aria-controls="mobile-nav-panel"
+          @click="mobileMenuOpen = !mobileMenuOpen"
+        >
+          <Menu v-if="!mobileMenuOpen" :size="22" />
+          <X v-else :size="22" />
         </button>
 
-        <!-- Mobile nav overlay -->
-        <div v-if="mobileMenuOpen" class="mobile-nav-overlay" @click="mobileMenuOpen = false"></div>
-        <nav v-if="mobileMenuOpen" class="mobile-nav-panel" aria-label="Mobile navigation">
-          <a href="/product" @click.prevent="mobileMenuOpen = false; openPublicPage('product')">Product <ChevronDown :size="13" /></a>
-          <a href="/solutions" @click.prevent="mobileMenuOpen = false; openPublicPage('solutions')">Solutions <ChevronDown :size="13" /></a>
-          <a href="/marketplace" @click.prevent="mobileMenuOpen = false; openPublicPage('marketplace')">Marketplace</a>
-          <a href="/how-it-works" @click.prevent="mobileMenuOpen = false; openPublicPage('how-it-works')">How it works</a>
-          <a href="/ledger" @click.prevent="mobileMenuOpen = false; openPublicPage('ledger')">Ledger Logs</a>
+        <div v-if="mobileMenuOpen" class="mobile-nav-overlay" aria-hidden="true" @click="mobileMenuOpen = false"></div>
+        <nav v-if="mobileMenuOpen" id="mobile-nav-panel" class="mobile-nav-panel" aria-label="Mobile navigation">
+          <a href="/product" :class="{ 'nav-active': publicPage === 'product' }" @click.prevent="mobileMenuOpen = false; openPublicPage('product')">Product <ChevronDown :size="13" /></a>
+          <a href="/solutions" :class="{ 'nav-active': publicPage === 'solutions' }" @click.prevent="mobileMenuOpen = false; openPublicPage('solutions')">Solutions <ChevronDown :size="13" /></a>
+          <a href="/marketplace" :class="{ 'nav-active': publicPage === 'marketplace' }" @click.prevent="mobileMenuOpen = false; openPublicPage('marketplace')">Marketplace</a>
+          <a href="/how-it-works" :class="{ 'nav-active': publicPage === 'how-it-works' }" @click.prevent="mobileMenuOpen = false; openPublicPage('how-it-works')">How it works</a>
+          <a href="/ledger" :class="{ 'nav-active': publicPage === 'ledger' }" @click.prevent="mobileMenuOpen = false; openPublicPage('ledger')">Ledger Logs</a>
         </nav>
 
         <div class="nav-actions">
@@ -2260,6 +2266,7 @@ import {
   Lock,
   LockKeyhole,
   Mail,
+  Menu,
   MessageCircle,
   MoreHorizontal,
   PenLine,

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -317,6 +317,69 @@ svg {
   padding: 8px 10px;
 }
 
+/* Hamburger menu button — hidden on desktop, shown on mobile via media query */
+.hamburger-button {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #ffffff;
+  color: #111827;
+  padding: 0;
+  cursor: pointer;
+  flex: 0 0 auto;
+}
+
+/* Mobile nav overlay — full-screen backdrop */
+.mobile-nav-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 45;
+  background: rgba(0, 0, 0, 0.32);
+  backdrop-filter: blur(4px);
+}
+
+/* Mobile nav panel — slide-in from right */
+.mobile-nav-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  z-index: 50;
+  width: min(300px, 80vw);
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  border-left: 1px solid var(--line);
+  background: #ffffff;
+  box-shadow: -8px 0 32px rgba(15, 23, 42, 0.1);
+  padding: 72px 24px 24px;
+  overflow-y: auto;
+}
+
+.mobile-nav-panel a {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: #273244;
+  padding: 12px 14px;
+  font-size: 14px;
+  font-weight: 750;
+  text-decoration: none;
+  transition: background 160ms ease, color 160ms ease;
+}
+
+.mobile-nav-panel a:hover {
+  background: var(--soft);
+  color: var(--green-dark);
+}
+
 .dash-icon-button.light {
   border-color: var(--line);
   background: #ffffff;
@@ -6170,6 +6233,10 @@ svg {
 
   .nav-actions {
     min-width: auto;
+  }
+
+  .hamburger-button {
+    display: inline-flex;
   }
 
   .hero-section {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -317,9 +317,10 @@ svg {
   padding: 8px 10px;
 }
 
-/* Hamburger menu button — hidden on desktop, shown on mobile via media query */
 .hamburger-button {
   display: none;
+  position: relative;
+  z-index: 55;
   align-items: center;
   justify-content: center;
   width: 40px;
@@ -333,8 +334,8 @@ svg {
   flex: 0 0 auto;
 }
 
-/* Mobile nav overlay — full-screen backdrop */
 .mobile-nav-overlay {
+  display: none;
   position: fixed;
   inset: 0;
   z-index: 45;
@@ -342,15 +343,14 @@ svg {
   backdrop-filter: blur(4px);
 }
 
-/* Mobile nav panel — slide-in from right */
 .mobile-nav-panel {
+  display: none;
   position: fixed;
   top: 0;
   right: 0;
   z-index: 50;
   width: min(300px, 80vw);
   height: 100vh;
-  display: flex;
   flex-direction: column;
   gap: 4px;
   border-left: 1px solid var(--line);
@@ -377,6 +377,11 @@ svg {
 
 .mobile-nav-panel a:hover {
   background: var(--soft);
+  color: var(--green-dark);
+}
+
+.mobile-nav-panel a.nav-active {
+  background: var(--green-soft);
   color: var(--green-dark);
 }
 
@@ -6237,6 +6242,14 @@ svg {
 
   .hamburger-button {
     display: inline-flex;
+  }
+
+  .mobile-nav-overlay {
+    display: block;
+  }
+
+  .mobile-nav-panel {
+    display: flex;
   }
 
   .hero-section {


### PR DESCRIPTION
## Fix: Homepage has no mobile navigation

On screens narrower than 980px, `.nav-links` were hidden via `display: none` but no mobile navigation was provided.

## Changes

**App.vue** — Added hamburger toggle button + slide-in mobile nav panel + backdrop overlay
**styles.css** — 67 lines of CSS for hamburger button, overlay, panel, and media query

## Verification

| Viewport | Desktop nav | Hamburger | Panel opens | Closes | Overflow |
|----------|:---:|:---:|:---:|:---:|:---:|
| 375px | panel | ✅ | ✅ tap | ✅ X/backdrop | ✅ none |
| 430px | panel | ✅ | ✅ | ✅ | ✅ |
| 768px | panel | ✅ | ✅ | ✅ | ✅ |
| 1440px | direct | hidden | N/A | N/A | ✅ |

Build: `npm run build` passes.

Fixes #11