### PR TITLE
fix: add profile dropdown menu instead of immediate logout (Bounty #20)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -36,11 +36,19 @@
           <button class="dash-icon-button light" aria-label="Messages" type="button" @click="showToast('Opening messages...')">
             <MessageCircle :size="17" />
           </button>
-          <button class="dash-profile slim" type="button" @click="logout">
-            <span class="profile-avatar">{{ initialsFor(user.name || user.email) }}</span>
-            <span>{{ user.name || user.email || 'Signed-in user' }}</span>
-            <ChevronDown :size="14" />
-          </button>
+          <div class="profile-menu-wrapper">
+            <button class="dash-profile slim" type="button" @click="profileMenuOpen = !profileMenuOpen">
+              <span class="profile-avatar">{{ initialsFor(user.name || user.email) }}</span>
+              <span>{{ user.name || user.email || 'Signed-in user' }}</span>
+              <ChevronDown :size="14" />
+            </button>
+            <div v-if="profileMenuOpen" class="profile-dropdown">
+              <button type="button" @click="profileMenuOpen = false; logout()">
+                <LogOut :size="16" />
+                Log out
+              </button>
+            </div>
+          </div>
         </template>
         <template v-else>
           <button class="secondary-button compact" type="button" @click="openAuthFromProjectWizard('login')">Log in</button>
@@ -1059,14 +1067,22 @@
             <Plus :size="16" />
             New Project
           </button>
-          <button class="dash-profile" type="button" @click="logout">
-            <span class="profile-avatar">{{ initialsFor(user.name || user.email) }}</span>
-            <span>
-              <strong>{{ user.name || user.email || 'Signed-in user' }}</strong>
-              <small>{{ user.wallet_address ? shortWallet(user.wallet_address) : 'Customer' }}</small>
-            </span>
-            <ChevronDown :size="14" />
-          </button>
+          <div class="profile-menu-wrapper">
+            <button class="dash-profile" type="button" @click="profileMenuOpen = !profileMenuOpen">
+              <span class="profile-avatar">{{ initialsFor(user.name || user.email) }}</span>
+              <span>
+                <strong>{{ user.name || user.email || 'Signed-in user' }}</strong>
+                <small>{{ user.wallet_address ? shortWallet(user.wallet_address) : 'Customer' }}</small>
+              </span>
+              <ChevronDown :size="14" />
+            </button>
+            <div v-if="profileMenuOpen" class="profile-dropdown">
+              <button type="button" @click="profileMenuOpen = false; logout()">
+                <LogOut :size="16" />
+                Log out
+              </button>
+            </div>
+          </div>
         </div>
       </header>
 
@@ -2380,6 +2396,7 @@ import {
   ListTodo,
   Lock,
   LockKeyhole,
+  LogOut,
   Mail,
   Menu,
   MessageCircle,
@@ -2518,6 +2535,13 @@ const authRememberMe = ref(false);
 const authTermsAccepted = ref(true);
 const errorMessage = ref('');
 const mobileMenuOpen = ref(false);
+const profileMenuOpen = ref(false);
+
+function dismissProfileMenu(event) {
+  if (!event.target?.closest?.('.profile-menu-wrapper')) {
+    profileMenuOpen.value = false;
+  }
+}
 const showPassword = ref(false);
 const showConfirmPassword = ref(false);
 const toastMessage = ref('');
@@ -4909,10 +4933,9 @@ function clearSession() {
   authReturnToProjectWizard.value = false;
   removeStoredToken();
 
-  if (!publicModeVisible.value || projectWizardVisible.value) {
-    projectWizardVisible.value = false;
-    openPublicPage('home');
-  }
+  projectWizardVisible.value = false;
+  publicModeVisible.value = true;
+  openPublicPage('home');
 }
 
 async function submitAuth() {
@@ -4972,6 +4995,7 @@ async function logout() {
     publicModeVisible.value = true;
     publicPage.value = 'home';
     updatePublicBrowserPath('home', true);
+    profileMenuOpen.value = false;
     showToast('Logged out.');
   }
 }
@@ -4993,6 +5017,7 @@ onMounted(async () => {
   const handledGitHubCallback = await handleGitHubCallback();
   if (hasWindow) {
     window.addEventListener('popstate', syncPublicPageFromBrowserPath);
+    window.addEventListener('click', dismissProfileMenu);
     if (!handledGitHubCallback) {
       if (projectWizardVisible.value) {
         updateProjectWizardBrowserPath(true);
@@ -5014,6 +5039,7 @@ onUnmounted(() => {
   disconnectWebSocket();
   if (hasWindow) {
     window.removeEventListener('popstate', syncPublicPageFromBrowserPath);
+    window.removeEventListener('click', dismissProfileMenu);
   }
   stopDashboardRealtime();
 });

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -5396,6 +5396,43 @@ svg {
   font-weight: 750;
 }
 
+.profile-menu-wrapper {
+  position: relative;
+}
+
+.profile-dropdown {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 90;
+  min-width: 160px;
+  padding: 6px;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  background: #ffffff;
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.14);
+}
+
+.profile-dropdown button {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 12px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: #dc2626;
+  font-size: 14px;
+  font-weight: 750;
+  cursor: pointer;
+  text-align: left;
+}
+
+.profile-dropdown button:hover {
+  background: #fef2f2;
+}
+
 .dash-content {
   min-width: 0;
   max-width: 100%;


### PR DESCRIPTION
## Bounty #20 — Fix logout bug (200 MRG)

### Claim Reference
Bounty #20

### Changes Made
1. **Added profile dropdown menu**: Clicking the profile button now toggles a dropdown menu instead of immediately logging out. The dropdown contains a "Log out" option with a LogOut icon.
2. **Fixed both profile button locations**: Updated both the project wizard navbar (line 39) and the dashboard topbar (line 1062) profile buttons.
3. **Added click-outside dismissal**: Clicking outside the profile menu wrapper automatically closes the dropdown.
4. **Fixed clearSession navigation**: `clearSession()` now unconditionally sets `publicModeVisible = true` and calls `openPublicPage("home")` to ensure the user always returns to the public homepage after logout, regardless of previous state.
5. **Reset profileMenuOpen on logout**: The `logout()` function now also resets `profileMenuOpen` to false.
6. **Added LogOut icon import**: Imported `LogOut` from `@lucide/vue`.
7. **Added CSS for profile dropdown**: Positioned absolutely, with proper z-index, border, shadow, and hover states.

### Build & Test Evidence
- `npm run build:local`: ✅ Passes (both client and SSR builds succeed)
- `node --test server.test.js`: ✅ All 9 tests pass

### Files Changed
- `frontend/src/App.vue` — Template, script, and logic changes
- `frontend/src/styles.css` — Added `.profile-menu-wrapper` and `.profile-dropdown` styles