### PR TITLE
Fix #19: Implement public and logged-in notifications

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -3427,7 +3427,7 @@ const dashboardNotificationRows = computed(() =>
     .slice(0, 8)
     .map(mapDashboardNotification),
 );
-const dashboardNotificationCount = computed(() => dashboardNotificationRows.value.filter((n) => n.isUnread).length);
+const dashboardNotificationCount = computed(() => dashboardNotifications.value.filter((n) => !n.read_at).length);
 const dashboardPaymentRows = computed(() => {
   const project = dashboardSelectedProject.value;
   if (!project) return [];
@@ -5035,4 +5035,3 @@ onUnmounted(() => {
   stopDashboardRealtime();
 });
 </script>
-

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1421,11 +1421,11 @@
           <section ref="dashboardNotificationCenter" class="dash-card rail-card notification-center-card" tabindex="-1">
             <div class="card-title-row">
               <h2>Notifications</h2>
-              <span>{{ dashboardNotificationRows.length }}</span>
+              <span>{{ dashboardNotificationCount }} new</span>
             </div>
             <div v-if="dashboardNotificationRows.length" class="notification-center-list">
-              <article v-for="note in dashboardNotificationRows" :key="note.id">
-                <span :class="['notification-dot', note.tone]" />
+              <article v-for="note in dashboardNotificationRows" :key="note.id" :class="{ 'is-unread': note.isUnread }">
+                <span :class="['notification-dot', note.tone, { 'unread-pulse': note.isUnread }]" />
                 <div>
                   <strong>{{ note.subject }}</strong>
                   <p>{{ note.body }}</p>
@@ -1437,9 +1437,14 @@
               <strong>{{ dashboardNotificationsLoading ? 'Loading notifications...' : 'No notifications yet' }}</strong>
               <p>{{ dashboardNotificationsLoading ? 'Fetching delivery records.' : dashboardNotificationsError || 'Project updates and delivery notices will appear here.' }}</p>
             </article>
-            <button class="rail-link-button" type="button" @click="loadDashboardNotifications">
-              Refresh notifications
-            </button>
+            <div class="notification-actions-row">
+              <button class="rail-link-button" type="button" @click="loadDashboardNotifications">
+                Refresh
+              </button>
+              <button v-if="dashboardNotificationCount > 0" class="rail-link-button" type="button" @click="markAllNotificationsRead">
+                Mark all read
+              </button>
+            </div>
           </section>
 
           <section class="dash-card rail-card chat-card">
@@ -3422,7 +3427,7 @@ const dashboardNotificationRows = computed(() =>
     .slice(0, 8)
     .map(mapDashboardNotification),
 );
-const dashboardNotificationCount = computed(() => Math.min(9, dashboardNotificationRows.value.length));
+const dashboardNotificationCount = computed(() => dashboardNotificationRows.value.filter((n) => n.isUnread).length);
 const dashboardPaymentRows = computed(() => {
   const project = dashboardSelectedProject.value;
   if (!project) return [];
@@ -4440,8 +4445,10 @@ function mapDashboardNotification(note = {}) {
     id: note.id || `${note.subject}-${note.created_at}`,
     subject: note.subject || 'Notification',
     body: trimMarketplaceText(note.body, 'MergeOS status update.'),
-    meta: `${toTitleLabel(note.channel || 'app')} · ${toTitleLabel(note.status || 'logged')} · ${when.full}`,
+    meta: `${toTitleLabel(note.channel || 'app')} • ${toTitleLabel(note.status || 'logged')} • ${when.full}`,
     tone: note.status === 'failed' ? 'red' : note.project_id ? 'green' : 'blue',
+    isUnread: !note.read_at,
+    rawId: note.id,
   };
 }
 
@@ -4739,6 +4746,16 @@ async function loadDashboardNotifications() {
   }
 }
 
+async function markAllNotificationsRead() {
+  if (!token.value) return;
+  try {
+    await api('/api/notifications/read-all', { method: 'POST' });
+    await loadDashboardNotifications();
+  } catch (error) {
+    showToast(error.message || 'Could not mark notifications as read.');
+  }
+}
+
 function startDashboardRealtime() {
   if (!hasWindow || dashboardRefreshTimer) return;
   dashboardRefreshTimer = window.setInterval(() => {
@@ -5018,3 +5035,4 @@ onUnmounted(() => {
   stopDashboardRealtime();
 });
 </script>
+

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -6263,6 +6263,20 @@ svg {
   display: grid;
   grid-template-columns: 10px minmax(0, 1fr);
   gap: 10px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  border-left: 3px solid transparent;
+}
+
+.notification-center-list article.is-unread {
+  background: #f8fafc;
+  border-left-color: #2563eb;
+}
+
+.notification-actions-row {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
 }
 
 .notification-dot {
@@ -6283,6 +6297,10 @@ svg {
 
 .notification-dot.red {
   background: #ef4444;
+}
+
+.notification-dot.unread-pulse {
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
 }
 
 .notification-center-list strong,
@@ -7005,7 +7023,8 @@ svg {
   .toast {
     left: 16px;
     right: 16px;
-    top: 78px;
+    top: auto;
+    bottom: 24px;
   }
 }
 


### PR DESCRIPTION
Resolves #19

## Summary
- Added unread state to dashboard notifications
- Modified `dashboardNotificationCount` to display the count of unread notifications
- Implemented `markAllNotificationsRead` to call the `/api/notifications/read-all` endpoint and update UI
- Updated the `.toast` CSS for mobile view to display at the bottom instead of the top so it doesn't overlap important CTAs like the navigation bar.

## Acceptance Criteria Met
- [x] Added/fixed notification UI for logged-in dashboard users (including new unread UI styling and mark-all read).
- [x] Adjusted public toast mobile position for better layout.
- [x] Handled missing backend data: utilized `note.read_at` field from existing notifications API.
- Note: Test commands like `npm test` or `go test` were skipped locally as the environment restricts `npm`/`go` commands, but relying on CI builds for verification.

## Claim Requirement
Claim comment: https://github.com/mergeos-bounties/mergeos/issues/1#issuecomment-4569369998