### PR TITLE
Fix project view horizontal overflow on dashboard (Issue #17)

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2177,7 +2177,7 @@ svg {
 
 .console-grid {
   display: grid;
-  grid-template-columns: 0.9fr 1.1fr 0.95fr;
+  grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr) minmax(0, 0.95fr);
   gap: 12px;
   margin-top: 14px;
 }
@@ -2416,7 +2416,7 @@ svg {
 
 .deploy-preview {
   display: grid;
-  grid-template-columns: 1fr 0.92fr;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 0.92fr);
   gap: 0;
   overflow: hidden;
   border: 1px solid #111827;
@@ -5438,6 +5438,7 @@ svg {
   justify-content: space-between;
   gap: 14px;
   margin-top: 16px;
+  flex-wrap: wrap;
 }
 
 .dash-project-header:focus {
@@ -5496,7 +5497,7 @@ svg {
 
 .dash-metrics {
   display: grid;
-  grid-template-columns: 0.85fr 1.1fr 0.75fr 1.3fr 0.8fr;
+  grid-template-columns: minmax(0, 0.85fr) minmax(0, 1.1fr) minmax(0, 0.75fr) minmax(0, 1.3fr) minmax(0, 0.8fr);
   gap: 14px;
   border-bottom: 1px solid var(--line);
   margin-top: 18px;


### PR DESCRIPTION
iixes #17

### Summary
This Pe fixes the horizontal overflow and layout clipping issues in the project detail view when opened from the authenticated dashboard.

1. \.dash-metrics\: Grid was using \r\ units without \minmax(0, ...)\. When child elements like repository UeLs had \white-space: nowrap\, the grid columns refused to shrink below their intrinsic widths, causing horizontal overflow. iixed by wrapping \r\ track sizes in \minmax(0, Xfr)\ so they can shrink below their content size.
2. \.dash-project-header\: Was missing \lex-wrap: wrap\. When the project title was wide, the header didn't wrap and pushed the action buttons out of view, causing overlap or clipping.

### Acceptance Criteria Verified
- eeproduce the logged-in dashboard -> project flow before fixing it: **Yes**
- iix the project view/navigation/layout issue after login: **Yes**
- Verified viewports: **1366x900, 768x900, 430x900, 390x664, 360x640**
- Test/Build output: 
  - \
pm test\ passed 100%.
  - \
pm run build:local\ built the production bundle successfully.
- Note on Data: Testing used **mocked dashboard data** to simulate long repository links and project names causing the overflow.

### Claim eequirement
Before opening this Pe, the claim requirement for issue 17 was fulfilled by the automated bounty system. I am submitting this code as the solution.
