### PR TITLE
fix(auth): correct logout state clearing sequence

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -5005,10 +5005,10 @@ async function logout() {
     console.warn('Backend logout failed gracefully', err);
   });
 
-  clearSession();
   publicModeVisible.value = true;
   publicPage.value = 'home';
   updatePublicBrowserPath('home', true);
+  clearSession();
   showToast('Logged out.');
 
   await req;


### PR DESCRIPTION
Fixes #20.

### Bug
Previously, `clearSession()` was called before `publicModeVisible.value = true` in the `logout()` handler. Since `clearSession` conditionally navigates based on the *current* public mode visibility (`!publicModeVisible.value`), the UI failed to reset correctly to the public home screen if logout was initiated from a deeply nested dashboard route, leaving the user with a broken view.

### Fix
Reordering the state mutations fixes the stuck authenticated dashboard layout and reliably returns the user to the public landing page on logout.

Bounty Wallet: 6sF8p22Gg83NKTJ6dvya7Srv4USCniZnP47DwQwK7Mtp (Solana) / Algora