### PR TITLE
feat: [5000 MRG] implement test-mode Publish Settings with database-backed integration keys (#141)

### DIFF
--- a/admin/src/App.vue
+++ b/admin/src/App.vue
@@ -597,6 +597,43 @@
           </article>
         </section>
 
+        <!-- Test Mode Publish Settings -->
+        <section class="test-publish-panel">
+          <div class="gemini-panel-head">
+            <span class="metric-icon purple"><KeyRound :size="19" /></span>
+            <div>
+              <span class="eyebrow">TEST MODE</span>
+              <h2>Publish Settings</h2>
+              <p>Allow bounty contributors to configure test integration keys at <strong>/publish-settings</strong> using a shared password.</p>
+            </div>
+          </div>
+          <div class="test-publish-status-row">
+            <span :class="['test-mode-badge', testModeStatus.enabled ? 'enabled' : 'disabled']">
+              {{ testModeStatus.enabled ? 'TEST MODE ENABLED' : 'TEST MODE DISABLED' }}
+            </span>
+            <span v-if="testModeStatus.password_is_set" class="test-mode-pw-hint">Password set</span>
+            <span v-else class="test-mode-pw-hint missing">No password set</span>
+          </div>
+          <div class="test-publish-actions">
+            <button class="primary-action" :disabled="testModeBusy" @click="toggleTestMode">
+              <KeyRound :size="16" />
+              {{ testModeStatus.enabled ? 'Disable test mode' : 'Enable test mode' }}
+            </button>
+          </div>
+          <form class="settings-form" style="margin-top:16px" @submit.prevent="saveTestModePassword">
+            <label>
+              <span>Set / Reset Public Test Password</span>
+              <input v-model.trim="testModePasswordInput" type="password" placeholder="Min 8 characters" autocomplete="new-password" />
+            </label>
+            <button class="primary-action" type="submit" :disabled="testModeBusy || !testModePasswordInput">
+              <Save :size="16" />
+              {{ testModeBusy ? 'Saving...' : 'Save password' }}
+            </button>
+          </form>
+          <p v-if="testModeError" class="form-error">{{ testModeError }}</p>
+          <p v-if="testModeMessage" class="form-success">{{ testModeMessage }}</p>
+        </section>
+
         <section class="gemini-control-panel">
           <div class="gemini-panel-head">
             <span class="metric-icon purple"><KeyRound :size="19" /></span>
@@ -807,6 +844,11 @@ const adminSettings = ref({});
 const settingsBusy = ref(false);
 const settingsError = ref('');
 const settingsMessage = ref('');
+const testModeStatus = ref({ enabled: false, password_is_set: false });
+const testModeBusy = ref(false);
+const testModeError = ref('');
+const testModeMessage = ref('');
+const testModePasswordInput = ref('');
 
 const loginForm = reactive({
   email: 'admin@gmail.com',
@@ -1138,6 +1180,7 @@ async function loadAdminData() {
     syncSettingsForm();
     geminiKeys.value = Array.isArray(geminiKeyData) ? geminiKeyData : [];
     geminiWebhookLogs.value = Array.isArray(geminiLogData) ? geminiLogData : [];
+    void fetchTestModeStatus();
     void syncTaskIssueStates(tasks.value);
     ensureSelectedUser();
   } catch (error) {
@@ -1274,6 +1317,53 @@ async function saveAdminSettings() {
     settingsError.value = error.message;
   } finally {
     settingsBusy.value = false;
+  }
+}
+
+async function fetchTestModeStatus() {
+  if (!token.value) return;
+  try {
+    const data = await api('/api/admin/test-publish/status');
+    testModeStatus.value = data || { enabled: false, password_is_set: false };
+  } catch (e) {
+    // non-fatal
+  }
+}
+
+async function toggleTestMode() {
+  testModeBusy.value = true;
+  testModeError.value = '';
+  testModeMessage.value = '';
+  try {
+    const result = await api('/api/admin/test-publish/status', {
+      method: 'PATCH',
+      body: JSON.stringify({ enabled: !testModeStatus.value.enabled }),
+    });
+    testModeStatus.value = result;
+    testModeMessage.value = result.enabled ? 'Test mode enabled.' : 'Test mode disabled.';
+  } catch (e) {
+    testModeError.value = e.message;
+  } finally {
+    testModeBusy.value = false;
+  }
+}
+
+async function saveTestModePassword() {
+  testModeBusy.value = true;
+  testModeError.value = '';
+  testModeMessage.value = '';
+  try {
+    const result = await api('/api/admin/test-publish/password', {
+      method: 'POST',
+      body: JSON.stringify({ password: testModePasswordInput.value }),
+    });
+    testModeStatus.value = result;
+    testModePasswordInput.value = '';
+    testModeMessage.value = 'Password saved successfully.';
+  } catch (e) {
+    testModeError.value = e.message;
+  } finally {
+    testModeBusy.value = false;
   }
 }
 

--- a/backend/internal/core/migrations/007_test_publish_settings.sql
+++ b/backend/internal/core/migrations/007_test_publish_settings.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS test_publish_settings (
+  id text PRIMARY KEY,
+  integration_type text NOT NULL,
+  display_name text NOT NULL DEFAULT '',
+  key_name text NOT NULL,
+  key_value text NOT NULL,
+  key_hint text NOT NULL DEFAULT '',
+  status text NOT NULL DEFAULT 'active',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  last_used_at timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS test_publish_settings_type_status_idx
+  ON test_publish_settings (integration_type, status);

--- a/backend/internal/core/models.go
+++ b/backend/internal/core/models.go
@@ -403,6 +403,86 @@ type AdminSettings struct {
 	LLMModel          string    `json:"llm_model"`
 	GeminiReviewModel string    `json:"gemini_review_model"`
 	UpdatedAt         time.Time `json:"updated_at"`
+
+	TestModeEnabled      bool   `json:"test_mode_enabled"`
+	TestModePasswordHash string `json:"test_mode_password_hash,omitempty"`
+	TestModePasswordSalt string `json:"test_mode_password_salt,omitempty"`
+}
+
+// TestPublishSetting is a database-backed test integration key.
+// KeyValue holds the raw secret and must never appear in API list responses.
+type TestPublishSetting struct {
+	ID              string     `json:"id"`
+	IntegrationType string     `json:"integration_type"`
+	DisplayName     string     `json:"display_name"`
+	KeyName         string     `json:"key_name"`
+	KeyValue        string     `json:"key_value"`
+	KeyHint         string     `json:"key_hint"`
+	Status          string     `json:"status"`
+	Provider        string     `json:"provider,omitempty"`
+	ClientID        string     `json:"client_id,omitempty"`
+	ReceiverAddress string     `json:"receiver_address,omitempty"`
+	CreatedAt       time.Time  `json:"created_at"`
+	UpdatedAt       time.Time  `json:"updated_at"`
+	LastUsedAt      *time.Time `json:"last_used_at,omitempty"`
+}
+
+// TestPublishSettingStats is the masked view returned by API responses.
+// KeyValue is excluded; only KeyHint is exposed.
+type TestPublishSettingStats struct {
+	ID              string     `json:"id"`
+	IntegrationType string     `json:"integration_type"`
+	DisplayName     string     `json:"display_name"`
+	KeyName         string     `json:"key_name"`
+	KeyHint         string     `json:"key_hint"`
+	Status          string     `json:"status"`
+	Provider        string     `json:"provider,omitempty"`
+	ClientID        string     `json:"client_id,omitempty"`
+	ReceiverAddress string     `json:"receiver_address,omitempty"`
+	CreatedAt       time.Time  `json:"created_at"`
+	UpdatedAt       time.Time  `json:"updated_at"`
+	LastUsedAt      *time.Time `json:"last_used_at,omitempty"`
+}
+
+type TestModeStatusResponse struct {
+	Enabled       bool      `json:"enabled"`
+	PasswordIsSet bool      `json:"password_is_set"`
+	UpdatedAt     time.Time `json:"updated_at"`
+}
+
+type SetTestModeRequest struct {
+	Enabled bool `json:"enabled"`
+}
+
+type SetTestModePasswordRequest struct {
+	Password string `json:"password"`
+}
+
+type VerifyTestModePasswordRequest struct {
+	Password string `json:"password"`
+}
+
+type VerifyTestModePasswordResponse struct {
+	OK bool `json:"ok"`
+}
+
+type AddTestPublishSettingRequest struct {
+	IntegrationType string `json:"integration_type"`
+	DisplayName     string `json:"display_name"`
+	KeyName         string `json:"key_name"`
+	KeyValue        string `json:"key_value"`
+	Provider        string `json:"provider,omitempty"`
+	ClientID        string `json:"client_id,omitempty"`
+	ReceiverAddress string `json:"receiver_address,omitempty"`
+}
+
+type UpdateTestPublishSettingRequest struct {
+	Status string `json:"status"`
+}
+
+type TestPublishSettingsResponse struct {
+	TestModeEnabled bool                      `json:"test_mode_enabled"`
+	Settings        []TestPublishSettingStats  `json:"settings"`
 }
 
 type LLMProviderOption struct {
@@ -634,3 +714,4 @@ type EvaluateProjectResponse struct {
 	Risks           []string         `json:"risks"`
 	Rationale       string           `json:"rationale"`
 }
+

--- a/backend/internal/core/server.go
+++ b/backend/internal/core/server.go
@@ -81,6 +81,16 @@ func (s *Server) Routes() http.Handler {
 	mux.HandleFunc("POST /api/notifications/read-all", s.markAllNotificationsRead)
 	mux.HandleFunc("GET /api/ws", s.wsHandler)
 	mux.HandleFunc("GET /api/ledger", s.ledger)
+	// Admin test-mode publish settings control
+	mux.HandleFunc("GET /api/admin/test-publish/status", s.adminTestPublishStatus)
+	mux.HandleFunc("PATCH /api/admin/test-publish/status", s.updateAdminTestPublishStatus)
+	mux.HandleFunc("POST /api/admin/test-publish/password", s.setAdminTestPublishPassword)
+	// Public test-mode publish settings (password-protected, no user login required)
+	mux.HandleFunc("POST /api/publish/authenticate", s.authenticateTestPublish)
+	mux.HandleFunc("GET /api/publish/settings", s.listTestPublishSettings)
+	mux.HandleFunc("POST /api/publish/settings/{type}", s.addTestPublishSetting)
+	mux.HandleFunc("PATCH /api/publish/settings/{type}/{id}", s.updateTestPublishSetting)
+	mux.HandleFunc("DELETE /api/publish/settings/{type}/{id}", s.deleteTestPublishSetting)
 	return withCORS(mux)
 }
 
@@ -927,4 +937,131 @@ func (s *Server) cryptoWebhook(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusCreated, project)
+}
+
+
+// requireTestPublishPassword reads the X-Test-Publish-Password header and verifies it.
+func (s *Server) requireTestPublishPassword(w http.ResponseWriter, r *http.Request) bool {
+	password := strings.TrimSpace(r.Header.Get("X-Test-Publish-Password"))
+	if err := s.store.VerifyTestModePassword(password); err != nil {
+		writeError(w, http.StatusUnauthorized, err.Error())
+		return false
+	}
+	return true
+}
+
+func (s *Server) adminTestPublishStatus(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requireAdmin(w, r); !ok {
+		return
+	}
+	writeJSON(w, http.StatusOK, s.store.GetTestModeStatus())
+}
+
+func (s *Server) updateAdminTestPublishStatus(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requireAdmin(w, r); !ok {
+		return
+	}
+	var req SetTestModeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	result, err := s.store.SetTestModeEnabled(req.Enabled)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, result)
+}
+
+func (s *Server) setAdminTestPublishPassword(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requireAdmin(w, r); !ok {
+		return
+	}
+	var req SetTestModePasswordRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	result, err := s.store.SetTestModePassword(req.Password)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, result)
+}
+
+func (s *Server) authenticateTestPublish(w http.ResponseWriter, r *http.Request) {
+	var req VerifyTestModePasswordRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if err := s.store.VerifyTestModePassword(req.Password); err != nil {
+		writeError(w, http.StatusUnauthorized, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, VerifyTestModePasswordResponse{OK: true})
+}
+
+func (s *Server) listTestPublishSettings(w http.ResponseWriter, r *http.Request) {
+	if !s.requireTestPublishPassword(w, r) {
+		return
+	}
+	integrationType := strings.TrimSpace(r.URL.Query().Get("type"))
+	settings := s.store.ListTestPublishSettings(integrationType)
+	status := s.store.GetTestModeStatus()
+	writeJSON(w, http.StatusOK, TestPublishSettingsResponse{
+		TestModeEnabled: status.Enabled,
+		Settings:        settings,
+	})
+}
+
+func (s *Server) addTestPublishSetting(w http.ResponseWriter, r *http.Request) {
+	if !s.requireTestPublishPassword(w, r) {
+		return
+	}
+	integrationType := r.PathValue("type")
+	var req AddTestPublishSettingRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	req.IntegrationType = integrationType
+	setting, err := s.store.AddTestPublishSetting(req)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, setting)
+}
+
+func (s *Server) updateTestPublishSetting(w http.ResponseWriter, r *http.Request) {
+	if !s.requireTestPublishPassword(w, r) {
+		return
+	}
+	id := r.PathValue("id")
+	var req UpdateTestPublishSettingRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	setting, err := s.store.UpdateTestPublishSetting(id, req.Status)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, setting)
+}
+
+func (s *Server) deleteTestPublishSetting(w http.ResponseWriter, r *http.Request) {
+	if !s.requireTestPublishPassword(w, r) {
+		return
+	}
+	id := r.PathValue("id")
+	if err := s.store.DeleteTestPublishSetting(id); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]bool{"deleted": true})
 }

--- a/backend/internal/core/store.go
+++ b/backend/internal/core/store.go
@@ -115,26 +115,28 @@ type Store struct {
 	notifications     map[string]*Notification
 	attachments       map[string]*Attachment
 	sslReviews        map[string]*SSLReviewStatus
-	geminiAPIKeys     map[string]*GeminiAPIKey
-	geminiWebhookLogs map[string]*GeminiWebhookLog
-	adminSettings     AdminSettings
-	ledger            []LedgerEntry
+	geminiAPIKeys       map[string]*GeminiAPIKey
+	geminiWebhookLogs   map[string]*GeminiWebhookLog
+	testPublishSettings map[string]*TestPublishSetting
+	adminSettings       AdminSettings
+	ledger              []LedgerEntry
 }
 
 type persistedState struct {
-	NextID            int                 `json:"next_id"`
-	Projects          []*Project          `json:"projects"`
-	Tasks             []*Task             `json:"tasks"`
-	Users             []*User             `json:"users"`
-	Wallets           []*Wallet           `json:"wallets"`
-	Sessions          []*Session          `json:"sessions"`
-	Notifications     []*Notification     `json:"notifications"`
-	Attachments       []*Attachment       `json:"attachments"`
-	SSLReviews        []*SSLReviewStatus  `json:"ssl_reviews"`
-	GeminiAPIKeys     []*GeminiAPIKey     `json:"gemini_api_keys"`
-	GeminiWebhookLogs []*GeminiWebhookLog `json:"gemini_webhook_logs"`
-	AdminSettings     *AdminSettings      `json:"admin_settings,omitempty"`
-	Ledger            []LedgerEntry       `json:"ledger"`
+	NextID              int                    `json:"next_id"`
+	Projects            []*Project             `json:"projects"`
+	Tasks               []*Task                `json:"tasks"`
+	Users               []*User                `json:"users"`
+	Wallets             []*Wallet              `json:"wallets"`
+	Sessions            []*Session             `json:"sessions"`
+	Notifications       []*Notification        `json:"notifications"`
+	Attachments         []*Attachment          `json:"attachments"`
+	SSLReviews          []*SSLReviewStatus     `json:"ssl_reviews"`
+	GeminiAPIKeys       []*GeminiAPIKey        `json:"gemini_api_keys"`
+	GeminiWebhookLogs   []*GeminiWebhookLog    `json:"gemini_webhook_logs"`
+	TestPublishSettings []*TestPublishSetting  `json:"test_publish_settings,omitempty"`
+	AdminSettings       *AdminSettings         `json:"admin_settings,omitempty"`
+	Ledger              []LedgerEntry          `json:"ledger"`
 }
 
 type statePersistence interface {
@@ -158,10 +160,11 @@ func NewStore(cfg Config, payments *PaymentManager, repos RepoFactory, emailer *
 		notifications:     map[string]*Notification{},
 		attachments:       map[string]*Attachment{},
 		sslReviews:        map[string]*SSLReviewStatus{},
-		geminiAPIKeys:     map[string]*GeminiAPIKey{},
-		geminiWebhookLogs: map[string]*GeminiWebhookLog{},
-		adminSettings:     defaultAdminSettings(cfg),
-		ledger:            []LedgerEntry{},
+		geminiAPIKeys:       map[string]*GeminiAPIKey{},
+		geminiWebhookLogs:   map[string]*GeminiWebhookLog{},
+		testPublishSettings: map[string]*TestPublishSetting{},
+		adminSettings:       defaultAdminSettings(cfg),
+		ledger:              []LedgerEntry{},
 	}
 	if strings.TrimSpace(cfg.DatabaseURL) != "" {
 		storage, err := newPostgresPersistence(context.Background(), cfg)
@@ -1687,6 +1690,7 @@ func (s *Store) applyState(state persistedState) bool {
 	s.sslReviews = map[string]*SSLReviewStatus{}
 	s.geminiAPIKeys = map[string]*GeminiAPIKey{}
 	s.geminiWebhookLogs = map[string]*GeminiWebhookLog{}
+	s.testPublishSettings = map[string]*TestPublishSetting{}
 	for _, project := range state.Projects {
 		if project == nil || project.ID == "" {
 			continue
@@ -1793,6 +1797,19 @@ func (s *Store) applyState(state persistedState) bool {
 		s.geminiWebhookLogs[logCopy.ID] = &logCopy
 	}
 	s.trimGeminiWebhookLogsLocked()
+	for _, setting := range state.TestPublishSettings {
+		if setting == nil || setting.ID == "" || strings.TrimSpace(setting.KeyValue) == "" {
+			continue
+		}
+		settingCopy := *setting
+		if settingCopy.Status == "" {
+			settingCopy.Status = TestPublishSettingStatusActive
+		}
+		if settingCopy.KeyHint == "" {
+			settingCopy.KeyHint = testPublishSettingHint(settingCopy.KeyValue)
+		}
+		s.testPublishSettings[settingCopy.ID] = &settingCopy
+	}
 	return migrated
 }
 
@@ -1817,10 +1834,11 @@ func (s *Store) snapshotLocked() persistedState {
 		Notifications:     make([]*Notification, 0, len(s.notifications)),
 		Attachments:       make([]*Attachment, 0, len(s.attachments)),
 		SSLReviews:        make([]*SSLReviewStatus, 0, len(s.sslReviews)),
-		GeminiAPIKeys:     make([]*GeminiAPIKey, 0, len(s.geminiAPIKeys)),
-		GeminiWebhookLogs: make([]*GeminiWebhookLog, 0, len(s.geminiWebhookLogs)),
-		AdminSettings:     cloneAdminSettings(s.adminSettings),
-		Ledger:            s.ledger,
+		GeminiAPIKeys:       make([]*GeminiAPIKey, 0, len(s.geminiAPIKeys)),
+		GeminiWebhookLogs:   make([]*GeminiWebhookLog, 0, len(s.geminiWebhookLogs)),
+		TestPublishSettings: make([]*TestPublishSetting, 0, len(s.testPublishSettings)),
+		AdminSettings:       cloneAdminSettings(s.adminSettings),
+		Ledger:              s.ledger,
 	}
 	for _, project := range s.projects {
 		state.Projects = append(state.Projects, cloneProject(project))
@@ -1867,6 +1885,13 @@ func (s *Store) snapshotLocked() persistedState {
 	}
 	sort.Slice(state.GeminiWebhookLogs, func(i, j int) bool {
 		return state.GeminiWebhookLogs[i].ReceivedAt.Before(state.GeminiWebhookLogs[j].ReceivedAt)
+	})
+	for _, setting := range s.testPublishSettings {
+		settingCopy := *setting
+		state.TestPublishSettings = append(state.TestPublishSettings, &settingCopy)
+	}
+	sort.Slice(state.TestPublishSettings, func(i, j int) bool {
+		return state.TestPublishSettings[i].ID < state.TestPublishSettings[j].ID
 	})
 	return state
 }
@@ -2263,3 +2288,4 @@ func (s *Store) IsPaymentReferenceUsed(reference string) bool {
 	}
 	return false
 }
+

--- a/backend/internal/core/test_publish.go
+++ b/backend/internal/core/test_publish.go
@@ -1,0 +1,352 @@
+package core
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	TestPublishSettingStatusActive   = "active"
+	TestPublishSettingStatusDisabled = "disabled"
+
+	IntegrationTypeLLM          = "llm"
+	IntegrationTypePayPalSandbox = "paypal_sandbox"
+	IntegrationTypeUSDTReceiver  = "usdt_receiver"
+)
+
+// blockedKeyNames lists ENV/config key names that must never be used as
+// database-backed test setting names to prevent collision with production config.
+var blockedKeyNames = map[string]struct{}{
+	"github_token":                {},
+	"mergeos_github_token":        {},
+	"token_symbol":                {},
+	"admin_email":                 {},
+	"admin_password":              {},
+	"paypal_client_id":            {},
+	"paypal_client_secret":        {},
+	"paypal_environment":          {},
+	"crypto_webhook_secret":       {},
+	"crypto_token_contract":       {},
+	"usdt_receiver_address":       {},
+	"gemini_api_keys":             {},
+	"database_url":                {},
+	"platform_fee_bps":            {},
+	"dev_payment_enabled":         {},
+	"dev_payment_code":            {},
+	"admin_name":                  {},
+	"admin_company_name":          {},
+	"admin_auto_promote":          {},
+	"primary_domain":              {},
+	"admin_domain":                {},
+	"scan_domain":                 {},
+	"ssl_review_enabled":          {},
+	"ssl_review_domains":          {},
+	"crypto_rpc_url":              {},
+	"crypto_receiver":             {},
+	"crypto_asset":                {},
+	"crypto_token_decimals":       {},
+	"crypto_wei_per_usd_cent":     {},
+	"crypto_min_confirmations":    {},
+	"gemini_review_model":         {},
+	"gemini_review_webhook_secret": {},
+	"gemini_review_max_patch_bytes": {},
+	"github_app_id":               {},
+	"github_oauth_client_id":      {},
+	"github_oauth_client_secret":  {},
+	"bounty_root":                 {},
+	"upload_root":                 {},
+	"smtp_host":                   {},
+	"smtp_port":                   {},
+	"smtp_username":               {},
+	"smtp_password":               {},
+	"smtp_from":                   {},
+	"google_client_id":            {},
+	"google_client_secret":        {},
+	"github_client_id":            {},
+	"github_client_secret":        {},
+}
+
+var validIntegrationTypes = map[string]struct{}{
+	IntegrationTypeLLM:          {},
+	IntegrationTypePayPalSandbox: {},
+	IntegrationTypeUSDTReceiver:  {},
+}
+
+func isBlockedKeyName(name string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(name))
+	if _, blocked := blockedKeyNames[normalized]; blocked {
+		return true
+	}
+	// Block anything that starts with mergeos_ to protect all MERGEOS_* env vars
+	if strings.HasPrefix(normalized, "mergeos_") {
+		return true
+	}
+	return false
+}
+
+func normalizeIntegrationType(t string) string {
+	t = strings.ToLower(strings.TrimSpace(t))
+	if _, ok := validIntegrationTypes[t]; ok {
+		return t
+	}
+	return ""
+}
+
+func testPublishSettingID(integrationType, keyName string) string {
+	sum := sha256.Sum256([]byte(integrationType + ":" + strings.TrimSpace(keyName) + ":" + time.Now().UTC().Format(time.RFC3339Nano)))
+	return hex.EncodeToString(sum[:])[:24]
+}
+
+func testPublishSettingHint(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) <= 8 {
+		return "****"
+	}
+	return value[:4] + "..." + value[len(value)-4:]
+}
+
+// Admin test mode control
+
+func (s *Store) GetTestModeStatus() TestModeStatusResponse {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return TestModeStatusResponse{
+		Enabled:         s.adminSettings.TestModeEnabled,
+		PasswordIsSet:   s.adminSettings.TestModePasswordHash != "",
+		UpdatedAt:       s.adminSettings.UpdatedAt,
+	}
+}
+
+func (s *Store) SetTestModeEnabled(enabled bool) (TestModeStatusResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.adminSettings.TestModeEnabled = enabled
+	s.adminSettings.UpdatedAt = time.Now().UTC()
+	if err := s.saveLocked(); err != nil {
+		return TestModeStatusResponse{}, err
+	}
+	return TestModeStatusResponse{
+		Enabled:       s.adminSettings.TestModeEnabled,
+		PasswordIsSet: s.adminSettings.TestModePasswordHash != "",
+		UpdatedAt:     s.adminSettings.UpdatedAt,
+	}, nil
+}
+
+func (s *Store) SetTestModePassword(password string) (TestModeStatusResponse, error) {
+	password = strings.TrimSpace(password)
+	if password == "" {
+		return TestModeStatusResponse{}, errors.New("test mode password is required")
+	}
+	if len(password) < 8 {
+		return TestModeStatusResponse{}, errors.New("test mode password must be at least 8 characters")
+	}
+	salt, hash, err := hashPassword(password)
+	if err != nil {
+		return TestModeStatusResponse{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.adminSettings.TestModePasswordHash = hash
+	s.adminSettings.TestModePasswordSalt = salt
+	s.adminSettings.UpdatedAt = time.Now().UTC()
+	if err := s.saveLocked(); err != nil {
+		return TestModeStatusResponse{}, err
+	}
+	return TestModeStatusResponse{
+		Enabled:       s.adminSettings.TestModeEnabled,
+		PasswordIsSet: true,
+		UpdatedAt:     s.adminSettings.UpdatedAt,
+	}, nil
+}
+
+// VerifyTestModePassword checks the supplied password against the stored hash.
+// Returns an error if test mode is disabled or the password is wrong.
+func (s *Store) VerifyTestModePassword(password string) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if !s.adminSettings.TestModeEnabled {
+		return errors.New("test mode is not enabled")
+	}
+	if s.adminSettings.TestModePasswordHash == "" {
+		return errors.New("test mode password has not been set")
+	}
+	if !verifyPassword(password, s.adminSettings.TestModePasswordSalt, s.adminSettings.TestModePasswordHash) {
+		return errors.New("invalid test mode password")
+	}
+	return nil
+}
+
+// Test publish settings CRUD
+
+func (s *Store) ListTestPublishSettings(integrationType string) []TestPublishSettingStats {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	integrationType = normalizeIntegrationType(integrationType)
+	result := make([]TestPublishSettingStats, 0)
+	for _, setting := range s.testPublishSettings {
+		if integrationType != "" && setting.IntegrationType != integrationType {
+			continue
+		}
+		result = append(result, testPublishSettingStats(setting))
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].IntegrationType != result[j].IntegrationType {
+			return result[i].IntegrationType < result[j].IntegrationType
+		}
+		return result[i].CreatedAt.Before(result[j].CreatedAt)
+	})
+	return result
+}
+
+func (s *Store) AddTestPublishSetting(req AddTestPublishSettingRequest) (TestPublishSettingStats, error) {
+	integrationType := normalizeIntegrationType(req.IntegrationType)
+	if integrationType == "" {
+		return TestPublishSettingStats{}, errors.New("invalid integration type: must be llm, paypal_sandbox, or usdt_receiver")
+	}
+	keyName := strings.TrimSpace(req.KeyName)
+	if keyName == "" {
+		return TestPublishSettingStats{}, errors.New("key name is required")
+	}
+	if isBlockedKeyName(keyName) {
+		return TestPublishSettingStats{}, errors.New("key name conflicts with a reserved environment variable name")
+	}
+	keyValue := strings.TrimSpace(req.KeyValue)
+	if keyValue == "" {
+		return TestPublishSettingStats{}, errors.New("key value is required")
+	}
+	displayName := strings.TrimSpace(req.DisplayName)
+	if displayName == "" {
+		displayName = keyName
+	}
+
+	if err := validateTestPublishSettingFields(integrationType, req); err != nil {
+		return TestPublishSettingStats{}, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.testPublishSettings == nil {
+		s.testPublishSettings = map[string]*TestPublishSetting{}
+	}
+	// Check for duplicate key name within same integration type
+	for _, existing := range s.testPublishSettings {
+		if existing.IntegrationType == integrationType && strings.EqualFold(existing.KeyName, keyName) {
+			return TestPublishSettingStats{}, errors.New("a setting with this key name already exists for this integration type")
+		}
+	}
+	now := time.Now().UTC()
+	id := testPublishSettingID(integrationType, keyName)
+	setting := &TestPublishSetting{
+		ID:              id,
+		IntegrationType: integrationType,
+		DisplayName:     displayName,
+		KeyName:         keyName,
+		KeyValue:        keyValue,
+		KeyHint:         testPublishSettingHint(keyValue),
+		Status:          TestPublishSettingStatusActive,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	s.testPublishSettings[id] = setting
+	if err := s.saveLocked(); err != nil {
+		return TestPublishSettingStats{}, err
+	}
+	return testPublishSettingStats(setting), nil
+}
+
+func (s *Store) UpdateTestPublishSetting(id, status string) (TestPublishSettingStats, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return TestPublishSettingStats{}, errors.New("setting id is required")
+	}
+	normalizedStatus := strings.ToLower(strings.TrimSpace(status))
+	if normalizedStatus != "" && normalizedStatus != TestPublishSettingStatusActive && normalizedStatus != TestPublishSettingStatusDisabled {
+		return TestPublishSettingStats{}, errors.New("invalid status: must be active or disabled")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	setting := s.testPublishSettings[id]
+	if setting == nil {
+		return TestPublishSettingStats{}, errors.New("setting not found")
+	}
+	if normalizedStatus != "" {
+		setting.Status = normalizedStatus
+	}
+	setting.UpdatedAt = time.Now().UTC()
+	if err := s.saveLocked(); err != nil {
+		return TestPublishSettingStats{}, err
+	}
+	return testPublishSettingStats(setting), nil
+}
+
+func (s *Store) DeleteTestPublishSetting(id string) error {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return errors.New("setting id is required")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.testPublishSettings == nil || s.testPublishSettings[id] == nil {
+		return errors.New("setting not found")
+	}
+	delete(s.testPublishSettings, id)
+	return s.saveLocked()
+}
+
+// GetTestPublishSettingsForRuntime returns active test settings for use by
+// test-mode code paths. Raw key values are returned only here (never in API responses).
+func (s *Store) GetTestPublishSettingsForRuntime(integrationType string) []TestPublishSetting {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	integrationType = normalizeIntegrationType(integrationType)
+	result := make([]TestPublishSetting, 0)
+	for _, setting := range s.testPublishSettings {
+		if setting.Status != TestPublishSettingStatusActive {
+			continue
+		}
+		if integrationType != "" && setting.IntegrationType != integrationType {
+			continue
+		}
+		result = append(result, *setting)
+	}
+	return result
+}
+
+func validateTestPublishSettingFields(integrationType string, req AddTestPublishSettingRequest) error {
+	switch integrationType {
+	case IntegrationTypeLLM:
+		if strings.TrimSpace(req.Provider) == "" {
+			return errors.New("provider is required for LLM keys")
+		}
+	case IntegrationTypePayPalSandbox:
+		if strings.TrimSpace(req.ClientID) == "" {
+			return errors.New("client_id is required for PayPal sandbox entries")
+		}
+	case IntegrationTypeUSDTReceiver:
+		if strings.TrimSpace(req.ReceiverAddress) == "" {
+			return errors.New("receiver_address is required for USDT receiver entries")
+		}
+	}
+	return nil
+}
+
+func testPublishSettingStats(s *TestPublishSetting) TestPublishSettingStats {
+	if s == nil {
+		return TestPublishSettingStats{}
+	}
+	return TestPublishSettingStats{
+		ID:              s.ID,
+		IntegrationType: s.IntegrationType,
+		DisplayName:     s.DisplayName,
+		KeyName:         s.KeyName,
+		KeyHint:         s.KeyHint,
+		Status:          s.Status,
+		CreatedAt:       s.CreatedAt,
+		UpdatedAt:       s.UpdatedAt,
+		LastUsedAt:      cloneTimePtr(s.LastUsedAt),
+	}
+}

--- a/backend/internal/core/test_publish_test.go
+++ b/backend/internal/core/test_publish_test.go
@@ -1,0 +1,288 @@
+package core
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsBlockedKeyName(t *testing.T) {
+	blocked := []string{
+		"GITHUB_TOKEN", "github_token",
+		"ADMIN_EMAIL", "admin_email",
+		"PAYPAL_CLIENT_ID",
+		"USDT_RECEIVER_ADDRESS",
+		"GEMINI_API_KEYS",
+		"MERGEOS_GITHUB_TOKEN",
+		"mergeos_anything",
+		"MERGEOS_FOO_BAR",
+	}
+	for _, name := range blocked {
+		if !isBlockedKeyName(name) {
+			t.Errorf("expected %q to be blocked", name)
+		}
+	}
+
+	allowed := []string{
+		"llm_test_keys",
+		"paypal_sandbox_test_accounts",
+		"usdt_test_receivers",
+		"my_custom_llm_key",
+		"openai_test_key",
+	}
+	for _, name := range allowed {
+		if isBlockedKeyName(name) {
+			t.Errorf("expected %q to be allowed", name)
+		}
+	}
+}
+
+func TestNormalizeIntegrationType(t *testing.T) {
+	cases := map[string]string{
+		"llm":            "llm",
+		"LLM":            "llm",
+		"paypal_sandbox": "paypal_sandbox",
+		"PAYPAL_SANDBOX": "paypal_sandbox",
+		"usdt_receiver":  "usdt_receiver",
+		"invalid":        "",
+		"":               "",
+	}
+	for input, want := range cases {
+		got := normalizeIntegrationType(input)
+		if got != want {
+			t.Errorf("normalizeIntegrationType(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestTestPublishSettingHint(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"short", "****"},
+		{"12345678", "1234...5678"},
+		{"sk-ant-api-key-value-here", "sk-a...here"},
+	}
+	for _, c := range cases {
+		got := testPublishSettingHint(c.input)
+		if got != c.want {
+			t.Errorf("testPublishSettingHint(%q) = %q, want %q", c.input, got, c.want)
+		}
+	}
+}
+
+func TestStoreTestPublishSettings(t *testing.T) {
+	store := newTestStore(t)
+
+	// Test mode disabled by default
+	status := store.GetTestModeStatus()
+	if status.Enabled {
+		t.Fatal("test mode should be disabled by default")
+	}
+
+	// Set password
+	_, err := store.SetTestModePassword("testpass123")
+	if err != nil {
+		t.Fatalf("SetTestModePassword: %v", err)
+	}
+
+	// Verify wrong password fails
+	err = store.VerifyTestModePassword("wrongpassword")
+	if err == nil {
+		t.Fatal("expected error for wrong password")
+	}
+
+	// Enable test mode
+	resp, err := store.SetTestModeEnabled(true)
+	if err != nil {
+		t.Fatalf("SetTestModeEnabled: %v", err)
+	}
+	if !resp.Enabled {
+		t.Fatal("test mode should be enabled")
+	}
+
+	// Verify correct password succeeds
+	err = store.VerifyTestModePassword("testpass123")
+	if err != nil {
+		t.Fatalf("VerifyTestModePassword: %v", err)
+	}
+
+	// Disable test mode — verify password now fails
+	_, err = store.SetTestModeEnabled(false)
+	if err != nil {
+		t.Fatalf("SetTestModeEnabled(false): %v", err)
+	}
+	err = store.VerifyTestModePassword("testpass123")
+	if err == nil {
+		t.Fatal("expected error when test mode is disabled")
+	}
+
+	// Re-enable for CRUD tests
+	store.SetTestModeEnabled(true)
+
+	// Add LLM key
+	llmReq := AddTestPublishSettingRequest{
+		IntegrationType: "llm",
+		DisplayName:     "OpenAI Test Key",
+		KeyName:         "openai_test_key",
+		KeyValue:        "sk-test-openai-key-value-here",
+		Provider:        "openai",
+	}
+	llmSetting, err := store.AddTestPublishSetting(llmReq)
+	if err != nil {
+		t.Fatalf("AddTestPublishSetting LLM: %v", err)
+	}
+	if llmSetting.KeyHint == llmSetting.KeyValue {
+		t.Fatal("key hint should not equal key value (secret must be masked)")
+	}
+	if strings.Contains(llmSetting.KeyHint, "sk-test-openai-key-value-here") {
+		t.Fatal("full key value must not appear in stats response")
+	}
+
+	// Add PayPal sandbox entry
+	paypalReq := AddTestPublishSettingRequest{
+		IntegrationType: "paypal_sandbox",
+		DisplayName:     "PayPal Sandbox Account 1",
+		KeyName:         "paypal_sandbox_test_accounts",
+		KeyValue:        "sandbox-secret-value",
+		ClientID:        "AXy_sandbox_client_id",
+	}
+	paypalSetting, err := store.AddTestPublishSetting(paypalReq)
+	if err != nil {
+		t.Fatalf("AddTestPublishSetting PayPal: %v", err)
+	}
+	if paypalSetting.IntegrationType != "paypal_sandbox" {
+		t.Fatal("wrong integration type stored")
+	}
+
+	// Add USDT receiver
+	usdtReq := AddTestPublishSettingRequest{
+		IntegrationType: "usdt_receiver",
+		DisplayName:     "USDT Test Receiver",
+		KeyName:         "usdt_test_receivers",
+		KeyValue:        "0xTestReceiverAddress",
+		ReceiverAddress: "0xTestReceiverAddress",
+	}
+	usdtSetting, err := store.AddTestPublishSetting(usdtReq)
+	if err != nil {
+		t.Fatalf("AddTestPublishSetting USDT: %v", err)
+	}
+
+	// List all settings
+	all := store.ListTestPublishSettings("")
+	if len(all) != 3 {
+		t.Fatalf("expected 3 settings, got %d", len(all))
+	}
+
+	// List by type
+	llmOnly := store.ListTestPublishSettings("llm")
+	if len(llmOnly) != 1 {
+		t.Fatalf("expected 1 LLM setting, got %d", len(llmOnly))
+	}
+
+	// Reject blocked key name
+	_, err = store.AddTestPublishSetting(AddTestPublishSettingRequest{
+		IntegrationType: "llm",
+		KeyName:         "GITHUB_TOKEN",
+		KeyValue:        "some-value",
+		Provider:        "openai",
+	})
+	if err == nil {
+		t.Fatal("expected error for blocked key name GITHUB_TOKEN")
+	}
+
+	// Reject mergeos_ prefix
+	_, err = store.AddTestPublishSetting(AddTestPublishSettingRequest{
+		IntegrationType: "llm",
+		KeyName:         "MERGEOS_CUSTOM_KEY",
+		KeyValue:        "some-value",
+		Provider:        "openai",
+	})
+	if err == nil {
+		t.Fatal("expected error for MERGEOS_* key name")
+	}
+
+	// Disable a setting
+	updated, err := store.UpdateTestPublishSetting(llmSetting.ID, TestPublishSettingStatusDisabled)
+	if err != nil {
+		t.Fatalf("UpdateTestPublishSetting: %v", err)
+	}
+	if updated.Status != TestPublishSettingStatusDisabled {
+		t.Fatal("setting should be disabled")
+	}
+
+	// Runtime resolution excludes disabled
+	runtime := store.GetTestPublishSettingsForRuntime("llm")
+	if len(runtime) != 0 {
+		t.Fatal("disabled setting should not appear in runtime resolution")
+	}
+
+	// Delete
+	if err := store.DeleteTestPublishSetting(paypalSetting.ID); err != nil {
+		t.Fatalf("DeleteTestPublishSetting: %v", err)
+	}
+	if err := store.DeleteTestPublishSetting(usdtSetting.ID); err != nil {
+		t.Fatalf("DeleteTestPublishSetting: %v", err)
+	}
+	remaining := store.ListTestPublishSettings("")
+	if len(remaining) != 1 {
+		t.Fatalf("expected 1 remaining setting, got %d", len(remaining))
+	}
+}
+
+func TestTestPublishSettingPasswordValidation(t *testing.T) {
+	store := newTestStore(t)
+
+	// Too short
+	_, err := store.SetTestModePassword("short")
+	if err == nil {
+		t.Fatal("expected error for short password")
+	}
+
+	// Empty
+	_, err = store.SetTestModePassword("")
+	if err == nil {
+		t.Fatal("expected error for empty password")
+	}
+
+	// Valid
+	_, err = store.SetTestModePassword("validpassword123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestTestPublishSettingArrayPersistence(t *testing.T) {
+	store := newTestStore(t)
+	store.SetTestModeEnabled(true)
+	store.SetTestModePassword("testpass123")
+
+	// Add 2 LLM keys
+	for i, name := range []string{"openai_key_one", "anthropic_key_two"} {
+		provider := "openai"
+		if i == 1 {
+			provider = "anthropic"
+		}
+		_, err := store.AddTestPublishSetting(AddTestPublishSettingRequest{
+			IntegrationType: "llm",
+			KeyName:         name,
+			KeyValue:        "sk-test-value-" + name,
+			Provider:        provider,
+		})
+		if err != nil {
+			t.Fatalf("AddTestPublishSetting: %v", err)
+		}
+	}
+
+	settings := store.ListTestPublishSettings("llm")
+	if len(settings) != 2 {
+		t.Fatalf("expected 2 LLM settings, got %d", len(settings))
+	}
+
+	// Verify secrets are masked in list response
+	for _, s := range settings {
+		if s.KeyHint == "" || len(s.KeyHint) > 20 {
+			t.Errorf("key hint looks wrong: %q", s.KeyHint)
+		}
+	}
+}

--- a/backend/internal/core/test_publish_test.go
+++ b/backend/internal/core/test_publish_test.go
@@ -1,9 +1,31 @@
 package core
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func newTestStoreForPublish(t *testing.T) *Store {
+	t.Helper()
+	tempDir := t.TempDir()
+	cfg := Config{
+		TokenSymbol:       defaultTokenSymbol,
+		StatePath:         filepath.Join(tempDir, "state.json"),
+		PlatformFeeBps:    1000,
+		DevPaymentEnabled: true,
+		DevPaymentCode:    defaultDevPaymentCode,
+		GitHubOwner:       defaultGitHubOwner,
+		BountyRoot:        filepath.Join(tempDir, "bounties"),
+		SMTPFrom:          "noreply@mergeos.local",
+	}
+	payments := NewPaymentManager(cfg)
+	store, err := NewStore(cfg, payments, NewRepoFactory(cfg), NewEmailSender(cfg))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
 
 func TestIsBlockedKeyName(t *testing.T) {
 	blocked := []string{
@@ -72,7 +94,7 @@ func TestTestPublishSettingHint(t *testing.T) {
 }
 
 func TestStoreTestPublishSettings(t *testing.T) {
-	store := newTestStore(t)
+	store := newTestStoreForPublish(t)
 
 	// Test mode disabled by default
 	status := store.GetTestModeStatus()
@@ -86,10 +108,10 @@ func TestStoreTestPublishSettings(t *testing.T) {
 		t.Fatalf("SetTestModePassword: %v", err)
 	}
 
-	// Verify wrong password fails
+	// Verify wrong password fails (mode not yet enabled)
 	err = store.VerifyTestModePassword("wrongpassword")
 	if err == nil {
-		t.Fatal("expected error for wrong password")
+		t.Fatal("expected error when test mode is disabled")
 	}
 
 	// Enable test mode
@@ -99,6 +121,12 @@ func TestStoreTestPublishSettings(t *testing.T) {
 	}
 	if !resp.Enabled {
 		t.Fatal("test mode should be enabled")
+	}
+
+	// Verify wrong password fails
+	err = store.VerifyTestModePassword("wrongpassword")
+	if err == nil {
+		t.Fatal("expected error for wrong password")
 	}
 
 	// Verify correct password succeeds
@@ -118,7 +146,9 @@ func TestStoreTestPublishSettings(t *testing.T) {
 	}
 
 	// Re-enable for CRUD tests
-	store.SetTestModeEnabled(true)
+	if _, err := store.SetTestModeEnabled(true); err != nil {
+		t.Fatal(err)
+	}
 
 	// Add LLM key
 	llmReq := AddTestPublishSettingRequest{
@@ -131,9 +161,6 @@ func TestStoreTestPublishSettings(t *testing.T) {
 	llmSetting, err := store.AddTestPublishSetting(llmReq)
 	if err != nil {
 		t.Fatalf("AddTestPublishSetting LLM: %v", err)
-	}
-	if llmSetting.KeyHint == llmSetting.KeyValue {
-		t.Fatal("key hint should not equal key value (secret must be masked)")
 	}
 	if strings.Contains(llmSetting.KeyHint, "sk-test-openai-key-value-here") {
 		t.Fatal("full key value must not appear in stats response")
@@ -231,7 +258,7 @@ func TestStoreTestPublishSettings(t *testing.T) {
 }
 
 func TestTestPublishSettingPasswordValidation(t *testing.T) {
-	store := newTestStore(t)
+	store := newTestStoreForPublish(t)
 
 	// Too short
 	_, err := store.SetTestModePassword("short")
@@ -253,11 +280,14 @@ func TestTestPublishSettingPasswordValidation(t *testing.T) {
 }
 
 func TestTestPublishSettingArrayPersistence(t *testing.T) {
-	store := newTestStore(t)
-	store.SetTestModeEnabled(true)
-	store.SetTestModePassword("testpass123")
+	store := newTestStoreForPublish(t)
+	if _, err := store.SetTestModeEnabled(true); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.SetTestModePassword("testpass123"); err != nil {
+		t.Fatal(err)
+	}
 
-	// Add 2 LLM keys
 	for i, name := range []string{"openai_key_one", "anthropic_key_two"} {
 		provider := "openai"
 		if i == 1 {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1900,6 +1900,121 @@
       </div>
     </main>
 
+
+    <main v-else-if="publicPage === 'publish-settings'" id="top" class="publish-settings-page">
+      <div class="publish-settings-container">
+        <h1 class="publish-settings-title">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+          Test Publish Settings
+        </h1>
+        <p class="publish-settings-subtitle">Configure test integration keys for active bounty work. Protected by the admin-set test mode password. Secret values are stored masked and never returned in full after save.</p>
+
+        <div v-if="!publishSettingsAuthed" class="publish-auth-card">
+          <h2>Enter test mode password</h2>
+          <p>Provide the shared public test password to access and configure test integration keys.</p>
+          <form @submit.prevent="authenticatePublishSettings" class="publish-auth-form">
+            <input v-model="publishSettingsPassword" type="password" placeholder="Test mode password" class="publish-auth-input" :disabled="publishSettingsLoading" autocomplete="current-password" />
+            <button type="submit" class="publish-auth-btn" :disabled="publishSettingsLoading || !publishSettingsPassword">
+              {{ publishSettingsLoading ? 'Verifying...' : 'Access Settings' }}
+            </button>
+          </form>
+          <p v-if="publishSettingsError" class="publish-auth-error">{{ publishSettingsError }}</p>
+        </div>
+
+        <template v-else>
+          <div class="publish-settings-toolbar">
+            <span class="publish-settings-mode-badge">TEST MODE ACTIVE</span>
+            <button class="publish-settings-logout-btn" @click="publishSettingsAuthed = false; publishSettingsPassword = ''; publishSettingsList = []">Lock</button>
+          </div>
+
+          <section class="publish-settings-section">
+            <div class="publish-section-header"><h2>LLM Test Keys</h2><button class="publish-add-btn" @click="openAddPublishSetting('llm')">+ Add Key</button></div>
+            <div v-if="!publishSettingsList.filter(s => s.integration_type === 'llm').length" class="publish-empty">No LLM test keys configured.</div>
+            <table v-else class="publish-settings-table">
+              <thead><tr><th>Name</th><th>Provider</th><th>Key (masked)</th><th>Status</th><th>Added</th><th></th></tr></thead>
+              <tbody>
+                <tr v-for="s in publishSettingsList.filter(s => s.integration_type === 'llm')" :key="s.id">
+                  <td>{{ s.display_name || s.key_name }}</td><td><code>{{ s.provider }}</code></td>
+                  <td><code class="publish-hint">{{ s.key_hint }}</code></td>
+                  <td><span :class="['publish-status-badge', s.status]">{{ s.status }}</span></td>
+                  <td>{{ new Date(s.created_at).toLocaleDateString() }}</td>
+                  <td class="publish-actions">
+                    <button class="publish-action-btn" @click="togglePublishSetting(s, s.status === 'active' ? 'disabled' : 'active')">{{ s.status === 'active' ? 'Disable' : 'Enable' }}</button>
+                    <button class="publish-action-btn danger" @click="deletePublishSetting(s)">Delete</button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+
+          <section class="publish-settings-section">
+            <div class="publish-section-header"><h2>PayPal Sandbox Accounts</h2><button class="publish-add-btn" @click="openAddPublishSetting('paypal_sandbox')">+ Add Account</button></div>
+            <div v-if="!publishSettingsList.filter(s => s.integration_type === 'paypal_sandbox').length" class="publish-empty">No PayPal sandbox accounts configured.</div>
+            <table v-else class="publish-settings-table">
+              <thead><tr><th>Name</th><th>Client ID</th><th>Secret (masked)</th><th>Status</th><th>Added</th><th></th></tr></thead>
+              <tbody>
+                <tr v-for="s in publishSettingsList.filter(s => s.integration_type === 'paypal_sandbox')" :key="s.id">
+                  <td>{{ s.display_name || s.key_name }}</td><td><code>{{ s.client_id || '—' }}</code></td>
+                  <td><code class="publish-hint">{{ s.key_hint }}</code></td>
+                  <td><span :class="['publish-status-badge', s.status]">{{ s.status }}</span></td>
+                  <td>{{ new Date(s.created_at).toLocaleDateString() }}</td>
+                  <td class="publish-actions">
+                    <button class="publish-action-btn" @click="togglePublishSetting(s, s.status === 'active' ? 'disabled' : 'active')">{{ s.status === 'active' ? 'Disable' : 'Enable' }}</button>
+                    <button class="publish-action-btn danger" @click="deletePublishSetting(s)">Delete</button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+
+          <section class="publish-settings-section">
+            <div class="publish-section-header"><h2>USDT Test Receivers</h2><button class="publish-add-btn" @click="openAddPublishSetting('usdt_receiver')">+ Add Receiver</button></div>
+            <div v-if="!publishSettingsList.filter(s => s.integration_type === 'usdt_receiver').length" class="publish-empty">No USDT test receivers configured.</div>
+            <table v-else class="publish-settings-table">
+              <thead><tr><th>Name</th><th>Receiver Address</th><th>Secret (masked)</th><th>Status</th><th>Added</th><th></th></tr></thead>
+              <tbody>
+                <tr v-for="s in publishSettingsList.filter(s => s.integration_type === 'usdt_receiver')" :key="s.id">
+                  <td>{{ s.display_name || s.key_name }}</td><td><code>{{ s.receiver_address || '—' }}</code></td>
+                  <td><code class="publish-hint">{{ s.key_hint }}</code></td>
+                  <td><span :class="['publish-status-badge', s.status]">{{ s.status }}</span></td>
+                  <td>{{ new Date(s.created_at).toLocaleDateString() }}</td>
+                  <td class="publish-actions">
+                    <button class="publish-action-btn" @click="togglePublishSetting(s, s.status === 'active' ? 'disabled' : 'active')">{{ s.status === 'active' ? 'Disable' : 'Enable' }}</button>
+                    <button class="publish-action-btn danger" @click="deletePublishSetting(s)">Delete</button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+        </template>
+      </div>
+
+      <div v-if="addPublishSettingOpen" class="publish-modal-backdrop" @click.self="addPublishSettingOpen = false">
+        <div class="publish-modal">
+          <button class="publish-modal-close" @click="addPublishSettingOpen = false">×</button>
+          <h2>Add {{ addPublishSettingType === 'llm' ? 'LLM Test Key' : addPublishSettingType === 'paypal_sandbox' ? 'PayPal Sandbox Account' : 'USDT Test Receiver' }}</h2>
+          <form @submit.prevent="submitAddPublishSetting" class="publish-modal-form">
+            <label>Display Name<input v-model="addPublishSettingForm.display_name" type="text" placeholder="e.g. OpenAI staging key" /></label>
+            <label>Key Name <small>(no reserved ENV/config names)</small><input v-model="addPublishSettingForm.key_name" type="text" placeholder="e.g. openai_test_key_1" required /></label>
+            <label v-if="addPublishSettingType === 'llm'">Provider
+              <select v-model="addPublishSettingForm.provider">
+                <option value="openai">OpenAI</option><option value="anthropic">Anthropic</option>
+                <option value="gemini">Gemini</option><option value="groq">Groq</option><option value="openrouter">OpenRouter</option>
+              </select>
+            </label>
+            <label v-if="addPublishSettingType === 'paypal_sandbox'">Client ID<input v-model="addPublishSettingForm.client_id" type="text" placeholder="PayPal sandbox client ID" required /></label>
+            <label v-if="addPublishSettingType === 'usdt_receiver'">Receiver Address<input v-model="addPublishSettingForm.receiver_address" type="text" placeholder="0x... or testnet address" required /></label>
+            <label>Secret Value <small>(stored masked — only hint shown after save)</small><input v-model="addPublishSettingForm.key_value" type="password" placeholder="API key, secret, or credential value" required autocomplete="new-password" /></label>
+            <p v-if="addPublishSettingError" class="publish-auth-error">{{ addPublishSettingError }}</p>
+            <div class="publish-modal-actions">
+              <button type="button" @click="addPublishSettingOpen = false">Cancel</button>
+              <button type="submit" :disabled="addPublishSettingLoading">{{ addPublishSettingLoading ? 'Saving...' : 'Save' }}</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </main>
+
     <main v-else-if="publicPage === 'marketplace'" id="top" class="marketplace-page">
       <div class="home-container marketplace-layout">
         <section class="marketplace-main">
@@ -2419,6 +2534,7 @@ const publicPagePaths = {
   marketplace: '/marketplace',
   'how-it-works': '/how-it-works',
   ledger: '/ledger',
+  'publish-settings': '/publish-settings',
 };
 const publicPageNames = new Set(Object.keys(publicPagePaths));
 const projectWizardStepPaths = {
@@ -2549,6 +2665,18 @@ const runtimeConfig = ref(null);
 const ledgerRawEntries = ref([]);
 const ledgerProjects = ref([]);
 const ledgerLoading = ref(false);
+
+const publishSettingsAuthed = ref(false);
+const publishSettingsPassword = ref('');
+const publishSettingsLoading = ref(false);
+const publishSettingsError = ref('');
+const publishSettingsList = ref([]);
+const addPublishSettingOpen = ref(false);
+const addPublishSettingType = ref('llm');
+const addPublishSettingLoading = ref(false);
+const addPublishSettingError = ref('');
+const addPublishSettingForm = ref({ display_name: '', key_name: '', key_value: '', provider: 'openai', client_id: '', receiver_address: '' });
+
 const ledgerError = ref('');
 const marketplaceData = ref({
   stats: {},
@@ -5055,4 +5183,89 @@ onUnmounted(() => {
   }
   stopDashboardRealtime();
 });
+
+
+async function authenticatePublishSettings() {
+  if (!publishSettingsPassword.value) return;
+  publishSettingsLoading.value = true;
+  publishSettingsError.value = '';
+  try {
+    const resp = await api('/api/publish/authenticate', {
+      method: 'POST',
+      body: JSON.stringify({ password: publishSettingsPassword.value })
+    });
+    if (resp && resp.ok) {
+      publishSettingsAuthed.value = true;
+      await loadPublishSettings();
+    }
+  } catch (e) {
+    publishSettingsError.value = e?.message || 'Invalid password or test mode is disabled';
+  } finally {
+    publishSettingsLoading.value = false;
+  }
+}
+
+async function loadPublishSettings() {
+  try {
+    const data = await api('/api/publish/settings', {
+      headers: { 'X-Test-Publish-Password': publishSettingsPassword.value }
+    });
+    publishSettingsList.value = data?.settings || [];
+  } catch (e) {
+    publishSettingsError.value = e?.message || 'Failed to load settings';
+    publishSettingsAuthed.value = false;
+  }
+}
+
+function openAddPublishSetting(type) {
+  addPublishSettingType.value = type;
+  addPublishSettingForm.value = { display_name: '', key_name: '', key_value: '', provider: 'openai', client_id: '', receiver_address: '' };
+  addPublishSettingError.value = '';
+  addPublishSettingOpen.value = true;
+}
+
+async function submitAddPublishSetting() {
+  addPublishSettingLoading.value = true;
+  addPublishSettingError.value = '';
+  try {
+    await api(`/api/publish/settings/${addPublishSettingType.value}`, {
+      method: 'POST',
+      headers: { 'X-Test-Publish-Password': publishSettingsPassword.value },
+      body: JSON.stringify(addPublishSettingForm.value)
+    });
+    addPublishSettingOpen.value = false;
+    await loadPublishSettings();
+  } catch (e) {
+    addPublishSettingError.value = e?.message || 'Failed to save setting';
+  } finally {
+    addPublishSettingLoading.value = false;
+  }
+}
+
+async function togglePublishSetting(setting, status) {
+  try {
+    await api(`/api/publish/settings/${setting.integration_type}/${setting.id}`, {
+      method: 'PATCH',
+      headers: { 'X-Test-Publish-Password': publishSettingsPassword.value },
+      body: JSON.stringify({ status })
+    });
+    await loadPublishSettings();
+  } catch (e) {
+    showToast(e?.message || 'Failed to update setting');
+  }
+}
+
+async function deletePublishSetting(setting) {
+  if (!confirm('Delete this test setting?')) return;
+  try {
+    await api(`/api/publish/settings/${setting.integration_type}/${setting.id}`, {
+      method: 'DELETE',
+      headers: { 'X-Test-Publish-Password': publishSettingsPassword.value }
+    });
+    await loadPublishSettings();
+  } catch (e) {
+    showToast(e?.message || 'Failed to delete setting');
+  }
+}
+
 </script>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -9008,3 +9008,54 @@ svg {
   }
 }
 
+
+/* ============================================================
+   Publish Settings page — test-mode integration key management
+   ============================================================ */
+.publish-settings-page { min-height: 80vh; padding: 40px 20px; }
+.publish-settings-container { max-width: 960px; margin: 0 auto; }
+.publish-settings-title { display: flex; align-items: center; gap: 12px; font-size: 1.8rem; margin-bottom: 8px; }
+.publish-settings-subtitle { color: var(--color-muted, #888); margin-bottom: 32px; }
+.publish-auth-card { background: var(--color-surface, #fff); border: 1px solid var(--color-border, #e0e0e0); border-radius: 12px; padding: 32px; max-width: 420px; }
+.publish-auth-card h2 { margin-bottom: 8px; font-size: 1.1rem; }
+.publish-auth-card p { color: var(--color-muted, #888); margin-bottom: 20px; font-size: 0.9rem; }
+.publish-auth-form { display: flex; flex-direction: column; gap: 12px; }
+.publish-auth-input { padding: 10px 14px; border: 1px solid var(--color-border, #e0e0e0); border-radius: 8px; font-size: 1rem; width: 100%; }
+.publish-auth-btn { padding: 10px 20px; background: var(--color-primary, #6366f1); color: #fff; border: none; border-radius: 8px; cursor: pointer; font-size: 1rem; }
+.publish-auth-btn:disabled { opacity: 0.6; cursor: not-allowed; }
+.publish-auth-error { color: #e74c3c; font-size: 0.85rem; margin-top: 4px; }
+.publish-settings-toolbar { display: flex; align-items: center; gap: 12px; margin-bottom: 24px; }
+.publish-settings-mode-badge { background: #22c55e22; color: #16a34a; border: 1px solid #16a34a44; border-radius: 6px; padding: 4px 12px; font-size: 0.75rem; font-weight: 700; letter-spacing: 0.05em; }
+.publish-settings-logout-btn { margin-left: auto; padding: 6px 14px; border: 1px solid var(--color-border, #e0e0e0); border-radius: 6px; cursor: pointer; background: transparent; }
+.publish-settings-section { background: var(--color-surface, #fff); border: 1px solid var(--color-border, #e0e0e0); border-radius: 12px; padding: 24px; margin-bottom: 24px; }
+.publish-section-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 16px; }
+.publish-section-header h2 { font-size: 1.05rem; margin: 0; }
+.publish-add-btn { padding: 6px 14px; background: var(--color-primary, #6366f1); color: #fff; border: none; border-radius: 6px; cursor: pointer; font-size: 0.85rem; }
+.publish-settings-table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
+.publish-settings-table th { text-align: left; padding: 8px 12px; border-bottom: 1px solid var(--color-border, #e0e0e0); color: var(--color-muted, #888); font-weight: 600; }
+.publish-settings-table td { padding: 10px 12px; border-bottom: 1px solid var(--color-border-light, #f0f0f0); }
+.publish-hint { font-family: monospace; background: var(--color-code-bg, #f5f5f5); padding: 2px 6px; border-radius: 4px; }
+.publish-status-badge { padding: 2px 8px; border-radius: 4px; font-size: 0.75rem; font-weight: 600; }
+.publish-status-badge.active { background: #22c55e22; color: #16a34a; }
+.publish-status-badge.disabled { background: #f1f5f9; color: #94a3b8; }
+.publish-actions { display: flex; gap: 6px; }
+.publish-action-btn { padding: 4px 10px; border: 1px solid var(--color-border, #e0e0e0); border-radius: 4px; cursor: pointer; font-size: 0.75rem; background: transparent; }
+.publish-action-btn.danger { color: #e74c3c; border-color: #e74c3c44; }
+.publish-empty { color: var(--color-muted, #888); font-size: 0.9rem; padding: 8px 0; }
+.publish-modal-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 1000; display: flex; align-items: center; justify-content: center; padding: 20px; }
+.publish-modal { background: var(--color-surface, #fff); border-radius: 12px; padding: 32px; width: 100%; max-width: 500px; position: relative; max-height: 90vh; overflow-y: auto; }
+.publish-modal-close { position: absolute; top: 16px; right: 16px; background: transparent; border: none; font-size: 1.5rem; cursor: pointer; line-height: 1; }
+.publish-modal h2 { margin-bottom: 20px; font-size: 1.1rem; }
+.publish-modal-form { display: flex; flex-direction: column; gap: 14px; }
+.publish-modal-form label { display: flex; flex-direction: column; gap: 4px; font-size: 0.85rem; font-weight: 600; }
+.publish-modal-form label small { font-weight: 400; color: var(--color-muted, #888); }
+.publish-modal-form input, .publish-modal-form select { padding: 8px 12px; border: 1px solid var(--color-border, #e0e0e0); border-radius: 6px; font-size: 0.9rem; }
+.publish-modal-actions { display: flex; gap: 10px; justify-content: flex-end; margin-top: 8px; }
+.publish-modal-actions button { padding: 8px 18px; border-radius: 6px; cursor: pointer; font-size: 0.9rem; }
+.publish-modal-actions button[type=submit] { background: var(--color-primary, #6366f1); color: #fff; border: none; }
+.publish-modal-actions button[type=submit]:disabled { opacity: 0.6; }
+.publish-modal-actions button[type=button] { background: transparent; border: 1px solid var(--color-border, #e0e0e0); }
+@media (max-width: 600px) {
+  .publish-settings-table { display: block; overflow-x: auto; }
+  .publish-settings-page { padding: 20px 12px; }
+}


### PR DESCRIPTION
## Summary

Full-stack implementation of the [5000 MRG] Test Publish Settings feature ([#141](https://github.com/mergeos-bounties/mergeos/issues/141)).

Allows admins to enable a public test mode and set a shared password. Contributors who know that password can access `/publish-settings` to configure test integration keys (LLM providers, PayPal Sandbox, USDT test receivers) — all stored in the database, never in `.env`.

## Claim

Bounty claimed: https://github.com/mergeos-bounties/mergeos/issues/1#issuecomment-4576818978

Repo starred ✓

## Changes

### Backend (`backend/internal/core/`)
- **`test_publish.go`** — New file: Store methods for test mode control and CRUD on test publish settings
  - `SetTestModeEnabled` / `SetTestModePassword` / `VerifyTestModePassword`
  - `ListTestPublishSettings` / `AddTestPublishSetting` / `UpdateTestPublishSetting` / `DeleteTestPublishSetting`
  - `GetTestPublishSettingsForRuntime` — returns raw key values for test-mode code paths only
  - ENV collision detection: blocks any key name matching reserved ENV vars or `MERGEOS_*` prefix
  - Secret masking: `KeyHint` shown in API responses, `KeyValue` excluded
- **`test_publish_test.go`** — Tests: password validation, disabled mode, CRUD, ENV collision rejection, array persistence, secret masking
- **`models.go`** — Added `TestPublishSetting`, `TestPublishSettingStats`, `TestModeStatusResponse`, request/response types; added `TestModeEnabled`, `TestModePasswordHash`, `TestModePasswordSalt` to `AdminSettings`
- **`store.go`** — Added `testPublishSettings map[string]*TestPublishSetting` to `Store`; updated `persistedState` and `snapshotLocked` / `applyState`
- **`server.go`** — Added 8 new routes:
  - `GET/PATCH /api/admin/test-publish/status` — admin toggle
  - `POST /api/admin/test-publish/password` — admin set password
  - `POST /api/publish/authenticate` — public password check
  - `GET /api/publish/settings` — list settings (requires `X-Test-Publish-Password` header)
  - `POST /api/publish/settings/{type}` — add setting
  - `PATCH /api/publish/settings/{type}/{id}` — enable/disable
  - `DELETE /api/publish/settings/{type}/{id}` — delete
- **`migrations/007_test_publish_settings.sql`** — Postgres table `test_publish_settings`

### Frontend (`frontend/src/`)
- **`App.vue`** — New `/publish-settings` route with:
  - Password gate (calls `POST /api/publish/authenticate`)
  - LLM Test Keys table with add/disable/delete
  - PayPal Sandbox Accounts table
  - USDT Test Receivers table
  - Add Setting modal for each integration type
  - "TEST MODE ACTIVE" badge, lock button
- **`styles.css`** — Responsive CSS for the Publish Settings page (mobile + desktop)

### Admin (`admin/src/`)
- **`App.vue`** — New "Test Mode Publish Settings" panel in the Settings view:
  - Enable/disable toggle
  - Set/reset public password form
  - Status badge showing current state and whether password is set

## Security

- Test mode password stored hashed (SHA-256 + random salt, same pattern as user passwords)
- Secret values masked in all API responses (only 4-char hint shown)
- Raw values returned only via `GetTestPublishSettingsForRuntime` (internal, never in HTTP responses)
- Public Publish Settings page completely blocked when test mode is disabled
- ENV/config key name collision detection prevents shadowing production variables
- No production ENV values exposed or modified

## Test Output

```
go test ./... (backend)
```
Tests cover:
- `TestIsBlockedKeyName` — ENV collision detection allows/rejects correct names
- `TestNormalizeIntegrationType` — type normalization
- `TestTestPublishSettingHint` — secret masking
- `TestStoreTestPublishSettings` — full CRUD + password flow + disable mode
- `TestTestPublishSettingPasswordValidation` — short/empty password rejection
- `TestTestPublishSettingArrayPersistence` — multiple entries per type, secret masking verified

## Payout Address

Solana: `9Yqndqd92Kv6nkwpgFwTp2kHuw9KLT1L4G5EUZ3LK8zq`
