### PR TITLE
[5000 MRG] feat: Build public test-mode Publish Settings for database-backed integration keys

### DIFF
--- a/admin/src/App.vue
+++ b/admin/src/App.vue
@@ -734,6 +734,93 @@
       </section>
     </section>
   </div>
+      <section v-else-if="activeView === 'test-settings'" class="settings-workspace">
+        <section class="settings-panel">
+          <div class="settings-panel-head">
+            <span class="metric-icon purple"><Settings2 :size="19" /></span>
+            <div>
+              <span class="eyebrow">TEST MODE</span>
+              <h2>Publish Settings</h2>
+              <p>Enable public test mode for bounty contributors. Contributors can configure integration keys without editing .env files.</p>
+            </div>
+          </div>
+
+          <form class="settings-form" @submit.prevent="saveTestSettingsConfig">
+            <div class="test-mode-toggle">
+              <label class="toggle-label">
+                <span>Test mode</span>
+                <span :class="['toggle-switch', testSettingsConfig.test_mode_enabled ? 'on' : 'off']" @click="toggleTestMode">
+                  <span class="toggle-knob"></span>
+                </span>
+                <strong>{{ testSettingsConfig.test_mode_enabled ? 'Enabled' : 'Disabled' }}</strong>
+              </label>
+              <p class="toggle-hint">When enabled, contributors with the password can access the public Publish Settings page.</p>
+            </div>
+
+            <label>
+              <span>New password</span>
+              <input v-model="testNewPassword" autocomplete="off" placeholder="Set a new public test password" type="password" />
+            </label>
+
+            <button class="primary-action" :disabled="testSettingsBusy" type="submit">
+              <Save :size="16" />
+              {{ testSettingsBusy ? 'Saving...' : 'Save settings' }}
+            </button>
+          </form>
+
+          <p v-if="testSettingsError" class="form-error">{{ testSettingsError }}</p>
+          <p v-if="testSettingsMessage" class="form-success">{{ testSettingsMessage }}</p>
+        </section>
+
+        <section class="settings-summary-grid" aria-label="Test mode status">
+          <article><span>Status</span><strong :style="{color: testSettingsConfig.test_mode_enabled ? '#22c55e' : '#f59e0b'}">{{ testSettingsConfig.test_mode_enabled ? 'ONLINE' : 'OFFLINE' }}</strong></article>
+          <article><span>Entries</span><strong>{{ testSettingsEntries.length }}</strong></article>
+        </section>
+
+        <section class="gemini-control-panel">
+          <div class="gemini-panel-head">
+            <span class="metric-icon purple"><KeyRound :size="19" /></span>
+            <div>
+              <span class="eyebrow">INTEGRATION KEYS</span>
+              <h2>Test entries</h2>
+              <p>Add LLM test keys, PayPal Sandbox credentials, and USDT test receiver settings.</p>
+            </div>
+          </div>
+
+          <form class="gemini-key-form" @submit.prevent="addTestEntry">
+            <label><span>Type</span>
+              <select v-model="testForm.integration_type">
+                <option value="llm">LLM</option>
+                <option value="paypal">PayPal Sandbox</option>
+                <option value="usdt">USDT</option>
+              </select>
+            </label>
+            <label><span>Name</span><input v-model.trim="testForm.display_name" placeholder="e.g. OpenAI Test" /></label>
+            <label><span>Key</span><input v-model.trim="testForm.setting_key" placeholder="e.g. llm_test_openai_key" /></label>
+            <label><span>Value</span><input v-model="testForm.setting_value" placeholder="Paste key" type="password" /></label>
+            <label><span>Metadata JSON</span><input v-model="testForm.key_value_json" placeholder='{"env":"sandbox"}' /></label>
+            <button class="primary-action" :disabled="testSettingsBusy" type="submit"><Save :size="16" /> Add entry</button>
+          </form>
+        </section>
+
+        <section class="table-panel">
+          <TableHeader title="Test settings entries" :count="testSettingsEntries.length" />
+          <DataTable :columns="['Key', 'Type', 'Name', 'Value (masked)', 'Status', 'Created', 'Actions']">
+            <tr v-for="entry in testSettingsEntries" :key="entry.id">
+              <td><strong>{{ entry.setting_key }}</strong><small>{{ entry.id }}</small></td>
+              <td><span class="status-pill blue">{{ entry.integration_type }}</span></td>
+              <td>{{ entry.display_name || '-' }}</td>
+              <td><code>{{ entry.setting_value_hint }}</code></td>
+              <td><span :class="['status-pill', entry.status === 'active' ? 'green' : 'amber']">{{ entry.status }}</span></td>
+              <td>{{ formatDate(entry.created_at) }}</td>
+              <td class="row-action">
+                <button class="compact-action" type="button" @click="deleteTestEntry(entry.id)"><span style="color:#ef4444;">Delete</span></button>
+              </td>
+            </tr>
+          </DataTable>
+        </section>
+      </section>
+
 </template>
 
 <script setup>
@@ -827,6 +914,21 @@ const settingsBusy = ref(false);
 const settingsError = ref('');
 const settingsMessage = ref('');
 
+// Test publish settings
+const testSettingsConfig = ref({});
+const testSettingsEntries = ref([]);
+const testSettingsBusy = ref(false);
+const testSettingsError = ref('');
+const testSettingsMessage = ref('');
+const testNewPassword = ref('');
+const testForm = reactive({
+  integration_type: 'llm',
+  display_name: '',
+  setting_key: '',
+  setting_value: '',
+  key_value_json: '{}',
+});
+
 const loginForm = reactive({
   email: 'admin@gmail.com',
   password: 'Admin123',
@@ -872,6 +974,7 @@ const navItems = [
   { id: 'ssl', label: 'SSL', title: 'SSL monitoring', kicker: 'SECURITY', icon: ShieldCheck },
   { id: 'setting', label: 'Setting', title: 'Settings', kicker: 'SYSTEM', icon: Settings2 },
   { id: 'logs', label: 'Log', title: 'Log', kicker: 'AUTOMATION', icon: KeyRound },
+  { id: 'test-settings', label: 'Test Settings', title: 'Test Publish Settings', kicker: 'TEST MODE', icon: Settings2 },
 ];
 
 const routeByView = {
@@ -884,12 +987,14 @@ const routeByView = {
   ssl: '/ssl',
   setting: '/setting',
   logs: '/logs',
+  testSettings: '/test-settings',
 };
 const viewByRoute = Object.entries(routeByView).reduce((routes, [view, route]) => {
   routes[route] = view;
   return routes;
 }, {});
 viewByRoute['/gemini'] = 'logs';
+viewByRoute['/test-settings'] = 'test-settings';
 
 const bountyOptions = [
   { id: 'future-small', label: 'Future small', reward_mrg: 25 },
@@ -991,6 +1096,7 @@ const adminCommandBody = computed(() => {
   if (activeView.value === 'ledger') return 'Credit MRG, audit verified records, and switch between public references and hash evidence.';
   if (activeView.value === 'users') return 'Inspect account activity, update roles, and keep admin access controlled from one panel.';
   if (activeView.value === 'setting') return 'Tune review models, provider tokens, quotas, and webhook health for the automation layer.';
+  if (activeView.value === 'test-settings') return 'Manage public test-mode publish settings, integration keys, and shared test password for bounty contributors.';
   return 'Monitor funded work, task queues, SSL health, user activity, and payout records from one operations surface.';
 });
 const adminCommandMetrics = computed(() => [
@@ -1168,6 +1274,8 @@ async function loadAdminData() {
       settingsData,
       geminiKeyData,
       geminiLogData,
+      testSettingsData,
+      testEntryData,
     ] = await Promise.all([
       api('/api/admin/summary'),
       api('/api/admin/users'),
@@ -1179,6 +1287,8 @@ async function loadAdminData() {
       api('/api/admin/settings'),
       api('/api/admin/gemini/keys'),
       api('/api/admin/gemini/webhooks?limit=100'),
+      api('/api/admin/test-settings'),
+      api('/api/admin/test-settings/entries'),
     ]);
     summary.value = summaryData || {};
     users.value = Array.isArray(userData) ? userData : [];
@@ -1191,6 +1301,8 @@ async function loadAdminData() {
     syncSettingsForm();
     geminiKeys.value = Array.isArray(geminiKeyData) ? geminiKeyData : [];
     geminiWebhookLogs.value = Array.isArray(geminiLogData) ? geminiLogData : [];
+    testSettingsConfig.value = testSettingsData || {};
+    testSettingsEntries.value = Array.isArray(testEntryData) ? testEntryData : [];
     void syncTaskIssueStates(tasks.value);
     ensureSelectedUser();
   } catch (error) {
@@ -1337,6 +1449,8 @@ async function loadGeminiAdminData() {
     const [keyData, logData] = await Promise.all([
       api('/api/admin/gemini/keys'),
       api('/api/admin/gemini/webhooks?limit=100'),
+      api('/api/admin/test-settings'),
+      api('/api/admin/test-settings/entries'),
     ]);
     geminiKeys.value = Array.isArray(keyData) ? keyData : [];
     geminiWebhookLogs.value = Array.isArray(logData) ? logData : [];
@@ -1836,4 +1950,56 @@ onMounted(() => {
 onBeforeUnmount(() => {
   if (hasWindow) window.removeEventListener('popstate', handlePopState);
 });
+
+// Test Settings
+async function saveTestSettingsConfig() {
+  testSettingsBusy.value = true; testSettingsError.value = ''; testSettingsMessage.value = '';
+  try {
+    const payload = {};
+    if (testNewPassword.value) payload.test_password = testNewPassword.value;
+    const updated = await api('/api/admin/test-settings', { method: 'PATCH', body: JSON.stringify(payload) });
+    testSettingsConfig.value = updated || {};
+    testSettingsMessage.value = testNewPassword.value ? 'Settings saved. Password updated.' : 'Settings saved.';
+    testNewPassword.value = '';
+  } catch (e) { testSettingsError.value = e.message; }
+  finally { testSettingsBusy.value = false; }
+}
+
+async function toggleTestMode() {
+  testSettingsBusy.value = true; testSettingsError.value = '';
+  try {
+    const updated = await api('/api/admin/test-settings', { method: 'PATCH', body: JSON.stringify({ test_mode_enabled: !testSettingsConfig.value.test_mode_enabled }) });
+    testSettingsConfig.value = updated || {};
+    testSettingsMessage.value = updated.test_mode_enabled ? 'Test mode enabled.' : 'Test mode disabled.';
+  } catch (e) { testSettingsError.value = e.message; }
+  finally { testSettingsBusy.value = false; }
+}
+
+async function addTestEntry() {
+  testSettingsBusy.value = true; testSettingsError.value = ''; testSettingsMessage.value = '';
+  try {
+    let km = {};
+    try { km = JSON.parse(testForm.key_value_json || '{}'); } catch { throw new Error('Invalid JSON metadata.'); }
+    const entry = await api('/api/admin/test-settings/entries', { method: 'POST', body: JSON.stringify({
+      integration_type: testForm.integration_type, display_name: testForm.display_name,
+      setting_key: testForm.setting_key, setting_value: testForm.setting_value, key_value_map: km }) });
+    testSettingsEntries.value = [entry, ...testSettingsEntries.value];
+    testForm.integration_type = 'llm'; testForm.display_name = ''; testForm.setting_key = '';
+    testForm.setting_value = ''; testForm.key_value_json = '{}';
+    testSettingsMessage.value = 'Added ' + entry.setting_key;
+  } catch (e) { testSettingsError.value = e.message; }
+  finally { testSettingsBusy.value = false; }
+}
+
+async function deleteTestEntry(id) {
+  if (!confirm('Delete this entry?')) return;
+  testSettingsBusy.value = true; testSettingsError.value = '';
+  try {
+    await api('/api/admin/test-settings/entries/' + encodeURIComponent(id), { method: 'DELETE' });
+    testSettingsEntries.value = testSettingsEntries.value.filter(e => e.id !== id);
+    testSettingsMessage.value = 'Entry deleted.';
+  } catch (e) { testSettingsError.value = e.message; }
+  finally { testSettingsBusy.value = false; }
+}
+
 </script>

--- a/admin/src/App.vue
+++ b/admin/src/App.vue
@@ -734,7 +734,7 @@
       </section>
     </section>
   </div>
-      <section v-else-if="activeView === 'test-settings'" class="settings-workspace">
+      <section v-if="activeView === 'test-settings'" class="settings-workspace">
         <section class="settings-panel">
           <div class="settings-panel-head">
             <span class="metric-icon purple"><Settings2 :size="19" /></span>

--- a/admin/src/styles.css
+++ b/admin/src/styles.css
@@ -2022,3 +2022,41 @@ body {
     padding: 16px;
   }
 }
+
+/* Test mode toggle switch */
+.test-mode-toggle {
+  margin-bottom: 1rem;
+}
+.toggle-label {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  cursor: pointer;
+}
+.toggle-switch {
+  position: relative;
+  width: 44px;
+  height: 24px;
+  background: #374151;
+  border-radius: 12px;
+  transition: background 0.2s;
+  display: inline-block;
+}
+.toggle-switch.on { background: #22c55e; }
+.toggle-switch.off { background: #6b7280; }
+.toggle-knob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 20px;
+  height: 20px;
+  background: white;
+  border-radius: 50%;
+  transition: transform 0.2s;
+}
+.toggle-switch.on .toggle-knob { transform: translateX(20px); }
+.toggle-hint {
+  margin-top: 0.25rem;
+  font-size: 0.75rem;
+  color: #9ca3af;
+}

--- a/backend/internal/core/migrations/007_test_publish_settings.sql
+++ b/backend/internal/core/migrations/007_test_publish_settings.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS test_settings_config (
+  id text PRIMARY KEY,
+  test_mode_enabled boolean NOT NULL DEFAULT false,
+  test_password_hash text NOT NULL DEFAULT '',
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS test_settings_entries (
+  id text PRIMARY KEY,
+  integration_type text NOT NULL,
+  display_name text NOT NULL DEFAULT '',
+  setting_key text NOT NULL,
+  setting_value text NOT NULL,
+  key_value_map jsonb NOT NULL DEFAULT '{}',
+  status text NOT NULL DEFAULT 'active',
+  last_used_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS test_settings_entries_type_idx ON test_settings_entries (integration_type);
+CREATE INDEX IF NOT EXISTS test_settings_entries_status_idx ON test_settings_entries (status);

--- a/backend/internal/core/postgres_persistence.go
+++ b/backend/internal/core/postgres_persistence.go
@@ -147,6 +147,12 @@ func (p *postgresPersistence) Load(ctx context.Context) (persistedState, bool, e
 	if err := p.loadLedger(ctx, &state); err != nil {
 		return persistedState{}, false, err
 	}
+	if err := p.loadTestSettingsConfig(ctx, &state); err != nil {
+		return persistedState{}, false, err
+	}
+	if err := p.loadTestSettingsEntries(ctx, &state); err != nil {
+		return persistedState{}, false, err
+	}
 	return state, true, nil
 }
 
@@ -159,7 +165,9 @@ SELECT EXISTS (SELECT 1 FROM store_meta WHERE key = 'next_id')
    OR EXISTS (SELECT 1 FROM projects)
    OR EXISTS (SELECT 1 FROM gemini_api_keys)
    OR EXISTS (SELECT 1 FROM gemini_webhook_logs)
-   OR EXISTS (SELECT 1 FROM ledger_entries)`).Scan(&found)
+   OR EXISTS (SELECT 1 FROM ledger_entries)
+   OR EXISTS (SELECT 1 FROM test_settings_config)
+   OR EXISTS (SELECT 1 FROM test_settings_entries)`).Scan(&found)
 	if err != nil {
 		return false, fmt.Errorf("check postgres state: %w", err)
 	}
@@ -535,6 +543,8 @@ func (p *postgresPersistence) Save(ctx context.Context, state persistedState) er
 	defer tx.Rollback()
 
 	for _, table := range []string{
+		"test_settings_entries",
+		"test_settings_config",
 		"ledger_entries",
 		"gemini_webhook_logs",
 		"gemini_api_keys",
@@ -605,6 +615,12 @@ VALUES ('llm_provider', $1, $2), ('llm_model', $3, $2)`, provider, settings.Upda
 		return err
 	}
 	if err := saveLedger(ctx, tx, state.Ledger); err != nil {
+		return err
+	}
+	if err := saveTestSettingsConfig(ctx, tx, state.TestSettingsConfig); err != nil {
+		return err
+	}
+	if err := saveTestSettingsEntries(ctx, tx, state.TestSettingsEntries); err != nil {
 		return err
 	}
 
@@ -885,4 +901,92 @@ func timePtr(value sql.NullTime) *time.Time {
 	}
 	t := value.Time
 	return &t
+}
+func (p *postgresPersistence) loadTestSettingsConfig(ctx context.Context, state *persistedState) error {
+	var raw string
+	err := p.db.QueryRowContext(ctx, `SELECT value FROM store_meta WHERE key = 'test_settings_config'`).Scan(&raw)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("load test_settings_config: %w", err)
+	}
+	var config TestSettingsConfig
+	if err := json.Unmarshal([]byte(raw), &config); err != nil {
+		return fmt.Errorf("parse test_settings_config: %w", err)
+	}
+	state.TestSettingsConfig = &config
+	return nil
+}
+
+func (p *postgresPersistence) loadTestSettingsEntries(ctx context.Context, state *persistedState) error {
+	rows, err := p.db.QueryContext(ctx, `SELECT id, integration_type, display_name, setting_key, setting_value, key_value_map, status, last_used_at, created_at, updated_at FROM test_settings_entries ORDER BY created_at, id`)
+	if err != nil {
+		return fmt.Errorf("load test_settings_entries: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var entry TestSettingsEntry
+		var kvRaw []byte
+		var lastUsedAt sql.NullTime
+		if err := rows.Scan(
+			&entry.ID, &entry.IntegrationType, &entry.DisplayName, &entry.SettingKey,
+			&entry.SettingValue, &kvRaw, &entry.Status, &lastUsedAt,
+			&entry.CreatedAt, &entry.UpdatedAt,
+		); err != nil {
+			return fmt.Errorf("scan test_settings_entry: %w", err)
+		}
+		entry.LastUsedAt = timePtr(lastUsedAt)
+		if len(kvRaw) > 0 {
+			if err := json.Unmarshal(kvRaw, &entry.KeyValueMap); err != nil {
+				return fmt.Errorf("decode key_value_map for entry %s: %w", entry.ID, err)
+			}
+		}
+		if entry.KeyValueMap == nil {
+			entry.KeyValueMap = map[string]string{}
+		}
+		state.TestSettingsEntries = append(state.TestSettingsEntries, &entry)
+	}
+	return rows.Err()
+}
+
+func saveTestSettingsConfig(ctx context.Context, tx *sql.Tx, config *TestSettingsConfig) error {
+	if config == nil {
+		return nil
+	}
+	raw, err := json.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("marshal test_settings_config: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO store_meta (key, value, updated_at) VALUES ('test_settings_config', $1, now())`, string(raw)); err != nil {
+		return fmt.Errorf("save test_settings_config: %w", err)
+	}
+	return nil
+}
+
+func saveTestSettingsEntries(ctx context.Context, tx *sql.Tx, entries []*TestSettingsEntry) error {
+	for _, entry := range entries {
+		if entry == nil || entry.ID == "" {
+			continue
+		}
+		if entry.CreatedAt.IsZero() {
+			entry.CreatedAt = time.Now().UTC()
+		}
+		if entry.UpdatedAt.IsZero() {
+			entry.UpdatedAt = entry.CreatedAt
+		}
+		kvRaw, err := json.Marshal(entry.KeyValueMap)
+		if err != nil {
+			return fmt.Errorf("encode key_value_map for entry %s: %w", entry.ID, err)
+		}
+		if _, err := tx.ExecContext(ctx, `INSERT INTO test_settings_entries (id, integration_type, display_name, setting_key, setting_value, key_value_map, status, last_used_at, created_at, updated_at) VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8, $9, $10) ON CONFLICT (id) DO UPDATE SET integration_type = EXCLUDED.integration_type, display_name = EXCLUDED.display_name, setting_key = EXCLUDED.setting_key, setting_value = EXCLUDED.setting_value, key_value_map = EXCLUDED.key_value_map, status = EXCLUDED.status, last_used_at = EXCLUDED.last_used_at, updated_at = EXCLUDED.updated_at`,
+			entry.ID, entry.IntegrationType, entry.DisplayName, entry.SettingKey,
+			entry.SettingValue, string(kvRaw), entry.Status, entry.LastUsedAt,
+			entry.CreatedAt, entry.UpdatedAt,
+		); err != nil {
+			return fmt.Errorf("save test_settings_entry %s: %w", entry.ID, err)
+		}
+	}
+	return nil
 }

--- a/backend/internal/core/postgres_persistence.go
+++ b/backend/internal/core/postgres_persistence.go
@@ -905,7 +905,7 @@ func timePtr(value sql.NullTime) *time.Time {
 func (p *postgresPersistence) loadTestSettingsConfig(ctx context.Context, state *persistedState) error {
 	var raw string
 	err := p.db.QueryRowContext(ctx, `SELECT value FROM store_meta WHERE key = 'test_settings_config'`).Scan(&raw)
-	if errors.Is(err, sql.ErrNoRows) {
+	if err == sql.ErrNoRows {
 		return nil
 	}
 	if err != nil {

--- a/backend/internal/core/postgres_persistence.go
+++ b/backend/internal/core/postgres_persistence.go
@@ -903,17 +903,16 @@ func timePtr(value sql.NullTime) *time.Time {
 	return &t
 }
 func (p *postgresPersistence) loadTestSettingsConfig(ctx context.Context, state *persistedState) error {
-	var raw string
-	err := p.db.QueryRowContext(ctx, `SELECT value FROM store_meta WHERE key = 'test_settings_config'`).Scan(&raw)
+	var config TestSettingsConfig
+	err := p.db.QueryRowContext(ctx, `
+SELECT test_mode_enabled, test_password_hash, updated_at
+FROM test_settings_config
+WHERE id = 'public'`).Scan(&config.TestModeEnabled, &config.TestPasswordHash, &config.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil
 	}
 	if err != nil {
 		return fmt.Errorf("load test_settings_config: %w", err)
-	}
-	var config TestSettingsConfig
-	if err := json.Unmarshal([]byte(raw), &config); err != nil {
-		return fmt.Errorf("parse test_settings_config: %w", err)
 	}
 	state.TestSettingsConfig = &config
 	return nil
@@ -955,11 +954,18 @@ func saveTestSettingsConfig(ctx context.Context, tx *sql.Tx, config *TestSetting
 	if config == nil {
 		return nil
 	}
-	raw, err := json.Marshal(config)
-	if err != nil {
-		return fmt.Errorf("marshal test_settings_config: %w", err)
+	if config.UpdatedAt.IsZero() {
+		config.UpdatedAt = time.Now().UTC()
 	}
-	if _, err := tx.ExecContext(ctx, `INSERT INTO store_meta (key, value, updated_at) VALUES ('test_settings_config', $1, now())`, string(raw)); err != nil {
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO test_settings_config (id, test_mode_enabled, test_password_hash, updated_at)
+VALUES ('public', $1, $2, $3)
+ON CONFLICT (id) DO UPDATE SET
+  test_mode_enabled = EXCLUDED.test_mode_enabled,
+  test_password_hash = EXCLUDED.test_password_hash,
+  updated_at = EXCLUDED.updated_at`,
+		config.TestModeEnabled, config.TestPasswordHash, config.UpdatedAt,
+	); err != nil {
 		return fmt.Errorf("save test_settings_config: %w", err)
 	}
 	return nil

--- a/backend/internal/core/server.go
+++ b/backend/internal/core/server.go
@@ -81,6 +81,22 @@ func (s *Server) Routes() http.Handler {
 	mux.HandleFunc("POST /api/notifications/read-all", s.markAllNotificationsRead)
 	mux.HandleFunc("GET /api/ws", s.wsHandler)
 	mux.HandleFunc("GET /api/ledger", s.ledger)
+
+	// Test publish settings - admin endpoints
+	mux.HandleFunc("GET /api/admin/test-settings", s.adminGetTestSettings)
+	mux.HandleFunc("PATCH /api/admin/test-settings", s.adminUpdateTestSettings)
+	mux.HandleFunc("GET /api/admin/test-settings/entries", s.adminListTestEntries)
+	mux.HandleFunc("POST /api/admin/test-settings/entries", s.adminAddTestEntry)
+	mux.HandleFunc("PATCH /api/admin/test-settings/entries/{id}", s.adminUpdateTestEntry)
+	mux.HandleFunc("DELETE /api/admin/test-settings/entries/{id}", s.adminDeleteTestEntry)
+
+	// Test publish settings - public endpoints (password-gated)
+	mux.HandleFunc("POST /api/public/test-settings/auth", s.publicTestSettingsAuth)
+	mux.HandleFunc("GET /api/public/test-settings/entries", s.publicListTestEntries)
+	mux.HandleFunc("POST /api/public/test-settings/entries", s.publicAddTestEntry)
+	mux.HandleFunc("PATCH /api/public/test-settings/entries/{id}", s.publicUpdateTestEntry)
+	mux.HandleFunc("DELETE /api/public/test-settings/entries/{id}", s.publicDeleteTestEntry)
+	mux.HandleFunc("GET /api/public/test-settings/status", s.publicTestStatus)
 	return withCORS(mux)
 }
 
@@ -712,7 +728,7 @@ func withCORS(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type,Authorization,X-Hub-Signature-256,X-GitHub-Event,X-GitHub-Delivery,X-MergeOS-Signature,X-MergeOS-Event")
-		w.Header().Set("Access-Control-Allow-Methods", "GET,POST,PATCH,OPTIONS")
+		w.Header().Set("Access-Control-Allow-Methods", "GET,POST,PATCH,DELETE,OPTIONS")
 		if r.Method == http.MethodOptions {
 			w.WriteHeader(http.StatusNoContent)
 			return

--- a/backend/internal/core/server.go
+++ b/backend/internal/core/server.go
@@ -92,7 +92,7 @@ func (s *Server) Routes() http.Handler {
 
 	// Test publish settings - public endpoints (password-gated)
 	mux.HandleFunc("POST /api/public/test-settings/auth", s.publicTestSettingsAuth)
-	mux.HandleFunc("GET /api/public/test-settings/entries", s.publicListTestEntries)
+	mux.HandleFunc("POST /api/public/test-settings/entries/list", s.publicListTestEntries)
 	mux.HandleFunc("POST /api/public/test-settings/entries", s.publicAddTestEntry)
 	mux.HandleFunc("PATCH /api/public/test-settings/entries/{id}", s.publicUpdateTestEntry)
 	mux.HandleFunc("DELETE /api/public/test-settings/entries/{id}", s.publicDeleteTestEntry)

--- a/backend/internal/core/store.go
+++ b/backend/internal/core/store.go
@@ -117,6 +117,8 @@ type Store struct {
 	sslReviews        map[string]*SSLReviewStatus
 	geminiAPIKeys     map[string]*GeminiAPIKey
 	geminiWebhookLogs map[string]*GeminiWebhookLog
+	testSettingsConfig   TestSettingsConfig
+	testSettingsEntries  map[string]*TestSettingsEntry
 	adminSettings     AdminSettings
 	ledger            []LedgerEntry
 }
@@ -134,6 +136,8 @@ type persistedState struct {
 	GeminiAPIKeys     []*GeminiAPIKey     `json:"gemini_api_keys"`
 	GeminiWebhookLogs []*GeminiWebhookLog `json:"gemini_webhook_logs"`
 	AdminSettings     *AdminSettings      `json:"admin_settings,omitempty"`
+	TestSettingsConfig  *TestSettingsConfig    `json:"test_settings_config,omitempty"`
+	TestSettingsEntries []*TestSettingsEntry   `json:"test_settings_entries,omitempty"`
 	Ledger            []LedgerEntry       `json:"ledger"`
 }
 
@@ -160,6 +164,8 @@ func NewStore(cfg Config, payments *PaymentManager, repos RepoFactory, emailer *
 		sslReviews:        map[string]*SSLReviewStatus{},
 		geminiAPIKeys:     map[string]*GeminiAPIKey{},
 		geminiWebhookLogs: map[string]*GeminiWebhookLog{},
+		testSettingsConfig:   TestSettingsConfig{},
+		testSettingsEntries:  map[string]*TestSettingsEntry{},
 		adminSettings:     defaultAdminSettings(cfg),
 		ledger:            []LedgerEntry{},
 	}
@@ -1793,6 +1799,20 @@ func (s *Store) applyState(state persistedState) bool {
 		s.geminiWebhookLogs[logCopy.ID] = &logCopy
 	}
 	s.trimGeminiWebhookLogsLocked()
+
+	// Test settings
+	s.testSettingsConfig = TestSettingsConfig{}
+	if state.TestSettingsConfig != nil {
+		s.testSettingsConfig = *state.TestSettingsConfig
+	}
+	s.testSettingsEntries = map[string]*TestSettingsEntry{}
+	for _, entry := range state.TestSettingsEntries {
+		if entry == nil || entry.ID == "" {
+			continue
+		}
+		s.testSettingsEntries[entry.ID] = entry
+	}
+
 	return migrated
 }
 
@@ -1820,6 +1840,8 @@ func (s *Store) snapshotLocked() persistedState {
 		GeminiAPIKeys:     make([]*GeminiAPIKey, 0, len(s.geminiAPIKeys)),
 		GeminiWebhookLogs: make([]*GeminiWebhookLog, 0, len(s.geminiWebhookLogs)),
 		AdminSettings:     cloneAdminSettings(s.adminSettings),
+		TestSettingsConfig: &s.testSettingsConfig,
+		TestSettingsEntries: make([]*TestSettingsEntry, 0, len(s.testSettingsEntries)),
 		Ledger:            s.ledger,
 	}
 	for _, project := range s.projects {

--- a/backend/internal/core/store.go
+++ b/backend/internal/core/store.go
@@ -1890,6 +1890,10 @@ func (s *Store) snapshotLocked() persistedState {
 	sort.Slice(state.GeminiWebhookLogs, func(i, j int) bool {
 		return state.GeminiWebhookLogs[i].ReceivedAt.Before(state.GeminiWebhookLogs[j].ReceivedAt)
 	})
+	for _, entry := range s.testSettingsEntries {
+		entryCopy := *entry
+		state.TestSettingsEntries = append(state.TestSettingsEntries, &entryCopy)
+	}
 	return state
 }
 

--- a/backend/internal/core/test_publish_settings.go
+++ b/backend/internal/core/test_publish_settings.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -14,8 +15,13 @@ import (
 
 type TestSettingsConfig struct {
 	TestModeEnabled  bool      `json:"test_mode_enabled"`
-	TestPasswordHash string    `json:"-"`
+	TestPasswordHash string    `json:"test_password_hash,omitempty"`
 	UpdatedAt        time.Time `json:"updated_at"`
+}
+
+type TestSettingsConfigResponse struct {
+	TestModeEnabled bool      `json:"test_mode_enabled"`
+	UpdatedAt       time.Time `json:"updated_at"`
 }
 
 type TestSettingsEntry struct {
@@ -156,6 +162,56 @@ func recordPasswordAttempt(ip string, success bool) {
 	}
 }
 
+func testSettingsConfigResponse(config TestSettingsConfig) TestSettingsConfigResponse {
+	return TestSettingsConfigResponse{
+		TestModeEnabled: config.TestModeEnabled,
+		UpdatedAt:       config.UpdatedAt,
+	}
+}
+
+func testSettingsRateLimitKey(r *http.Request) string {
+	remoteIP := normalizedClientIP(r.RemoteAddr)
+	if trustedProxyIP(remoteIP) {
+		if forwarded := firstForwardedClientIP(r.Header.Get("X-Forwarded-For")); forwarded != "" {
+			return forwarded
+		}
+		if realIP := normalizedClientIP(r.Header.Get("X-Real-IP")); realIP != "" {
+			return realIP
+		}
+	}
+	return remoteIP
+}
+
+func firstForwardedClientIP(value string) string {
+	for _, part := range strings.Split(value, ",") {
+		if ip := normalizedClientIP(part); ip != "" {
+			return ip
+		}
+	}
+	return ""
+}
+
+func normalizedClientIP(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if host, _, err := net.SplitHostPort(value); err == nil {
+		value = host
+	}
+	value = strings.Trim(value, "[]")
+	ip := net.ParseIP(value)
+	if ip == nil {
+		return ""
+	}
+	return ip.String()
+}
+
+func trustedProxyIP(value string) bool {
+	ip := net.ParseIP(value)
+	return ip != nil && (ip.IsLoopback() || ip.IsPrivate())
+}
+
 var knownEnvNames = []string{
 	"GITHUB_TOKEN", "MERGEOS_GITHUB_TOKEN", "TOKEN_SYMBOL",
 	"ADMIN_EMAIL", "ADMIN_PASSWORD",
@@ -266,7 +322,7 @@ func (s *Store) ListTestSettingsEntries() []*TestSettingsEntryResponse {
 			DisplayName: entry.DisplayName, SettingKey: entry.SettingKey,
 			SettingValueHint: SettingValueMask(entry.SettingValue),
 			KeyValueMap:      maskKeyValueMap(entry.KeyValueMap),
-			Status: entry.Status, LastUsedAt: entry.LastUsedAt,
+			Status:           entry.Status, LastUsedAt: entry.LastUsedAt,
 			CreatedAt: entry.CreatedAt, UpdatedAt: entry.UpdatedAt,
 		})
 	}
@@ -274,9 +330,9 @@ func (s *Store) ListTestSettingsEntries() []*TestSettingsEntryResponse {
 }
 
 var allowedIntegrationTypes = map[string]bool{
-	"llm":          true,
-	"paypal":       true,
-	"usdt":         true,
+	"llm":    true,
+	"paypal": true,
+	"usdt":   true,
 }
 
 var allowedEntryStatuses = map[string]bool{
@@ -335,8 +391,12 @@ func (s *Store) UpdateTestSettingsEntry(id string, req UpdateTestEntryRequest) (
 	}
 	if strings.TrimSpace(req.SettingKey) != "" {
 		var kvMapKeys []string
-		for k := range entry.KeyValueMap { kvMapKeys = append(kvMapKeys, k) }
-		for k := range req.KeyValueMap { kvMapKeys = append(kvMapKeys, k) }
+		for k := range entry.KeyValueMap {
+			kvMapKeys = append(kvMapKeys, k)
+		}
+		for k := range req.KeyValueMap {
+			kvMapKeys = append(kvMapKeys, k)
+		}
 		if err := checkForEnvCollision(req.SettingKey, kvMapKeys); err != nil {
 			return nil, err
 		}
@@ -346,15 +406,23 @@ func (s *Store) UpdateTestSettingsEntry(id string, req UpdateTestEntryRequest) (
 		entry.SettingValue = req.SettingValue
 	}
 	if req.KeyValueMap != nil {
-		if entry.KeyValueMap == nil { entry.KeyValueMap = map[string]string{} }
+		if entry.KeyValueMap == nil {
+			entry.KeyValueMap = map[string]string{}
+		}
 		// Check nested key_value_map keys for ENV collision even when setting_key unchanged
 		var mergedKeys []string
-		for k := range entry.KeyValueMap { mergedKeys = append(mergedKeys, k) }
-		for k := range req.KeyValueMap { mergedKeys = append(mergedKeys, k) }
+		for k := range entry.KeyValueMap {
+			mergedKeys = append(mergedKeys, k)
+		}
+		for k := range req.KeyValueMap {
+			mergedKeys = append(mergedKeys, k)
+		}
 		if err := checkForEnvCollision(entry.SettingKey, mergedKeys); err != nil {
 			return nil, err
 		}
-		for k, v := range req.KeyValueMap { entry.KeyValueMap[k] = v }
+		for k, v := range req.KeyValueMap {
+			entry.KeyValueMap[k] = v
+		}
 	}
 	if strings.TrimSpace(req.Status) != "" {
 		if !allowedEntryStatuses[strings.ToLower(strings.TrimSpace(req.Status))] {
@@ -386,139 +454,191 @@ func entryToResponse(entry *TestSettingsEntry) *TestSettingsEntryResponse {
 		DisplayName: entry.DisplayName, SettingKey: entry.SettingKey,
 		SettingValueHint: SettingValueMask(entry.SettingValue),
 		KeyValueMap:      maskKeyValueMap(entry.KeyValueMap),
-		Status: entry.Status, LastUsedAt: entry.LastUsedAt,
+		Status:           entry.Status, LastUsedAt: entry.LastUsedAt,
 		CreatedAt: entry.CreatedAt, UpdatedAt: entry.UpdatedAt,
 	}
 }
 
 func (s *Server) adminGetTestSettings(w http.ResponseWriter, r *http.Request) {
-	if _, ok := s.requireAdmin(w, r); !ok { return }
-	writeJSON(w, http.StatusOK, s.store.GetTestSettingsConfig())
+	if _, ok := s.requireAdmin(w, r); !ok {
+		return
+	}
+	writeJSON(w, http.StatusOK, testSettingsConfigResponse(s.store.GetTestSettingsConfig()))
 }
 
 func (s *Server) adminUpdateTestSettings(w http.ResponseWriter, r *http.Request) {
-	if _, ok := s.requireAdmin(w, r); !ok { return }
+	if _, ok := s.requireAdmin(w, r); !ok {
+		return
+	}
 	var req UpdateTestSettingsRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body"); return
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
 	}
 	config, err := s.store.UpdateTestSettingsConfig(req)
-	if err != nil { writeError(w, http.StatusBadRequest, err.Error()); return }
-	writeJSON(w, http.StatusOK, config)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, testSettingsConfigResponse(config))
 }
 
 func (s *Server) adminListTestEntries(w http.ResponseWriter, r *http.Request) {
-	if _, ok := s.requireAdmin(w, r); !ok { return }
+	if _, ok := s.requireAdmin(w, r); !ok {
+		return
+	}
 	writeJSON(w, http.StatusOK, s.store.ListTestSettingsEntries())
 }
 
 func (s *Server) adminAddTestEntry(w http.ResponseWriter, r *http.Request) {
-	if _, ok := s.requireAdmin(w, r); !ok { return }
+	if _, ok := s.requireAdmin(w, r); !ok {
+		return
+	}
 	var req AddTestEntryRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body"); return
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
 	}
 	entry, err := s.store.AddTestSettingsEntry(req)
-	if err != nil { writeError(w, http.StatusBadRequest, err.Error()); return }
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	writeJSON(w, http.StatusCreated, entry)
 }
 
 func (s *Server) adminUpdateTestEntry(w http.ResponseWriter, r *http.Request) {
-	if _, ok := s.requireAdmin(w, r); !ok { return }
+	if _, ok := s.requireAdmin(w, r); !ok {
+		return
+	}
 	var req UpdateTestEntryRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body"); return
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
 	}
 	entry, err := s.store.UpdateTestSettingsEntry(r.PathValue("id"), req)
-	if err != nil { writeError(w, http.StatusBadRequest, err.Error()); return }
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	writeJSON(w, http.StatusOK, entry)
 }
 
 func (s *Server) adminDeleteTestEntry(w http.ResponseWriter, r *http.Request) {
-	if _, ok := s.requireAdmin(w, r); !ok { return }
+	if _, ok := s.requireAdmin(w, r); !ok {
+		return
+	}
 	if err := s.store.DeleteTestSettingsEntry(r.PathValue("id")); err != nil {
-		writeError(w, http.StatusNotFound, err.Error()); return
+		writeError(w, http.StatusNotFound, err.Error())
+		return
 	}
 	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
 }
 
 func (s *Server) requireTestAuthBody(w http.ResponseWriter, r *http.Request) bool {
-	if !checkPasswordRateLimit(r.RemoteAddr) {
+	rateLimitKey := testSettingsRateLimitKey(r)
+	if !checkPasswordRateLimit(rateLimitKey) {
 		writeError(w, http.StatusTooManyRequests, "too many failed password attempts; try again later")
 		return false
 	}
 	cfg := s.store.GetTestSettingsConfig()
 	if !cfg.TestModeEnabled {
-		writeError(w, http.StatusForbidden, "test mode is disabled"); return false
+		writeError(w, http.StatusForbidden, "test mode is disabled")
+		return false
 	}
 	bodyBytes, err := io.ReadAll(r.Body)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "failed to read request body"); return false
+		writeError(w, http.StatusBadRequest, "failed to read request body")
+		return false
 	}
 	var req PublicTestSettingsRequest
 	if err := json.Unmarshal(bodyBytes, &req); err != nil {
-		writeError(w, http.StatusUnauthorized, "password is required"); return false
+		writeError(w, http.StatusUnauthorized, "password is required")
+		return false
 	}
 	r.Body = io.NopCloser(strings.NewReader(string(bodyBytes)))
 	valid := s.store.VerifyTestPassword(req.Password)
-	recordPasswordAttempt(r.RemoteAddr, valid)
+	recordPasswordAttempt(rateLimitKey, valid)
 	if !valid {
-		writeError(w, http.StatusUnauthorized, "invalid password"); return false
+		writeError(w, http.StatusUnauthorized, "invalid password")
+		return false
 	}
 	return true
 }
 
 func (s *Server) publicTestSettingsAuth(w http.ResponseWriter, r *http.Request) {
-	if !checkPasswordRateLimit(r.RemoteAddr) {
-		writeError(w, http.StatusTooManyRequests, "too many failed password attempts; try again later"); return
+	rateLimitKey := testSettingsRateLimitKey(r)
+	if !checkPasswordRateLimit(rateLimitKey) {
+		writeError(w, http.StatusTooManyRequests, "too many failed password attempts; try again later")
+		return
 	}
 	cfg := s.store.GetTestSettingsConfig()
 	if !cfg.TestModeEnabled {
-		writeError(w, http.StatusForbidden, "test mode is disabled"); return
+		writeError(w, http.StatusForbidden, "test mode is disabled")
+		return
 	}
 	var req PublicTestSettingsRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusUnauthorized, "password is required"); return
+		writeError(w, http.StatusUnauthorized, "password is required")
+		return
 	}
 	valid := s.store.VerifyTestPassword(req.Password)
-	recordPasswordAttempt(r.RemoteAddr, valid)
+	recordPasswordAttempt(rateLimitKey, valid)
 	if !valid {
-		writeError(w, http.StatusUnauthorized, "invalid password"); return
+		writeError(w, http.StatusUnauthorized, "invalid password")
+		return
 	}
 	writeJSON(w, http.StatusOK, map[string]bool{"authenticated": true})
 }
 
 func (s *Server) publicListTestEntries(w http.ResponseWriter, r *http.Request) {
-	if !s.requireTestAuthBody(w, r) { return }
+	if !s.requireTestAuthBody(w, r) {
+		return
+	}
 	writeJSON(w, http.StatusOK, s.store.ListTestSettingsEntries())
 }
 
 func (s *Server) publicAddTestEntry(w http.ResponseWriter, r *http.Request) {
-	if !s.requireTestAuthBody(w, r) { return }
+	if !s.requireTestAuthBody(w, r) {
+		return
+	}
 	var req AddTestEntryRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body"); return
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
 	}
 	entry, err := s.store.AddTestSettingsEntry(req)
-	if err != nil { writeError(w, http.StatusBadRequest, err.Error()); return }
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	writeJSON(w, http.StatusCreated, entry)
 }
 
 func (s *Server) publicUpdateTestEntry(w http.ResponseWriter, r *http.Request) {
-	if !s.requireTestAuthBody(w, r) { return }
+	if !s.requireTestAuthBody(w, r) {
+		return
+	}
 	var req UpdateTestEntryRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body"); return
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
 	}
 	entry, err := s.store.UpdateTestSettingsEntry(r.PathValue("id"), req)
-	if err != nil { writeError(w, http.StatusBadRequest, err.Error()); return }
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	writeJSON(w, http.StatusOK, entry)
 }
 
 func (s *Server) publicDeleteTestEntry(w http.ResponseWriter, r *http.Request) {
-	if !s.requireTestAuthBody(w, r) { return }
+	if !s.requireTestAuthBody(w, r) {
+		return
+	}
 	if err := s.store.DeleteTestSettingsEntry(r.PathValue("id")); err != nil {
-		writeError(w, http.StatusNotFound, err.Error()); return
+		writeError(w, http.StatusNotFound, err.Error())
+		return
 	}
 	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
 }

--- a/backend/internal/core/test_publish_settings.go
+++ b/backend/internal/core/test_publish_settings.go
@@ -1,0 +1,480 @@
+package core
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// ---------- Models ----------
+
+type TestSettingsConfig struct {
+	TestModeEnabled  bool      `json:"test_mode_enabled"`
+	TestPasswordHash string    `json:"-"`
+	UpdatedAt        time.Time `json:"updated_at"`
+}
+
+type TestSettingsEntry struct {
+	ID              string            `json:"id"`
+	IntegrationType string            `json:"integration_type"`
+	DisplayName     string            `json:"display_name"`
+	SettingKey      string            `json:"setting_key"`
+	SettingValue    string            `json:"-"`
+	KeyValueMap     map[string]string `json:"key_value_map"`
+	Status          string            `json:"status"`
+	LastUsedAt      *time.Time        `json:"last_used_at,omitempty"`
+	CreatedAt       time.Time         `json:"created_at"`
+	UpdatedAt       time.Time         `json:"updated_at"`
+}
+
+// ---------- API request/response types ----------
+
+type UpdateTestSettingsRequest struct {
+	TestModeEnabled *bool  `json:"test_mode_enabled,omitempty"`
+	TestPassword    string `json:"test_password,omitempty"`
+}
+
+type AddTestEntryRequest struct {
+	IntegrationType string            `json:"integration_type"`
+	DisplayName     string            `json:"display_name"`
+	SettingKey      string            `json:"setting_key"`
+	SettingValue    string            `json:"setting_value"`
+	KeyValueMap     map[string]string `json:"key_value_map"`
+}
+
+type UpdateTestEntryRequest struct {
+	DisplayName  string            `json:"display_name,omitempty"`
+	SettingKey   string            `json:"setting_key,omitempty"`
+	SettingValue string            `json:"setting_value,omitempty"`
+	KeyValueMap  map[string]string `json:"key_value_map,omitempty"`
+	Status       string            `json:"status,omitempty"`
+}
+
+type PublicTestSettingsRequest struct {
+	Password string `json:"password"`
+}
+
+type TestSettingsEntryResponse struct {
+	ID               string            `json:"id"`
+	IntegrationType  string            `json:"integration_type"`
+	DisplayName      string            `json:"display_name"`
+	SettingKey       string            `json:"setting_key"`
+	SettingValueHint string            `json:"setting_value_hint"`
+	KeyValueMap      map[string]string `json:"key_value_map"`
+	Status           string            `json:"status"`
+	LastUsedAt       *time.Time        `json:"last_used_at,omitempty"`
+	CreatedAt        time.Time         `json:"created_at"`
+	UpdatedAt        time.Time         `json:"updated_at"`
+}
+
+// ---------- Known env names for collision detection ----------
+
+var knownEnvNames = []string{
+	"GITHUB_TOKEN",
+	"MERGEOS_GITHUB_TOKEN",
+	"TOKEN_SYMBOL",
+	"ADMIN_EMAIL",
+	"ADMIN_PASSWORD",
+	"PAYPAL_CLIENT_ID",
+	"PAYPAL_CLIENT_SECRET",
+	"PAYPAL_ENVIRONMENT",
+	"CRYPTO_WEBHOOK_SECRET",
+	"CRYPTO_TOKEN_CONTRACT",
+	"USDT_RECEIVER_ADDRESS",
+	"GEMINI_API_KEYS",
+}
+
+// SettingValueMask returns a masked version of the value showing first 4 + last 4 characters.
+func SettingValueMask(value string) string {
+	if len(value) <= 8 {
+		if len(value) == 0 {
+			return "****"
+		}
+		return value[:1] + "****" + value[len(value)-1:]
+	}
+	return value[:4] + "****" + value[len(value)-4:]
+}
+
+// checkForEnvCollision checks if a setting_key collides with known env variable names.
+func checkForEnvCollision(key string) error {
+	upper := strings.ToUpper(strings.TrimSpace(key))
+	if upper == "" {
+		return nil
+	}
+	for _, known := range knownEnvNames {
+		if upper == known {
+			return fmt.Errorf("setting key %q collides with known environment variable %s", key, known)
+		}
+	}
+	if strings.HasPrefix(upper, "MERGEOS_") {
+		return fmt.Errorf("setting key %q collides with MERGEOS_* environment variable prefix", key)
+	}
+	return nil
+}
+
+// ---------- Store methods ----------
+
+func (s *Store) GetTestSettingsConfig() TestSettingsConfig {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.testSettingsConfig
+}
+
+func (s *Store) UpdateTestSettingsConfig(req UpdateTestSettingsRequest) (TestSettingsConfig, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if req.TestModeEnabled != nil {
+		s.testSettingsConfig.TestModeEnabled = *req.TestModeEnabled
+	}
+
+	if strings.TrimSpace(req.TestPassword) != "" {
+		salt, hash, err := hashPassword(req.TestPassword)
+		if err != nil {
+			return TestSettingsConfig{}, err
+		}
+		s.testSettingsConfig.TestPasswordHash = salt + ":" + hash
+	}
+
+	s.testSettingsConfig.UpdatedAt = time.Now().UTC()
+
+	if err := s.saveLocked(); err != nil {
+		return TestSettingsConfig{}, err
+	}
+	return s.testSettingsConfig, nil
+}
+
+// VerifyTestPassword performs constant-time comparison of the given password
+// against the stored hash salt:hash format.
+func (s *Store) VerifyTestPassword(password string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.testSettingsConfig.TestPasswordHash == "" {
+		return false
+	}
+	parts := strings.SplitN(s.testSettingsConfig.TestPasswordHash, ":", 2)
+	if len(parts) != 2 {
+		return false
+	}
+	return verifyPassword(password, parts[0], parts[1])
+}
+
+func (s *Store) ListTestSettingsEntries() []*TestSettingsEntryResponse {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	responses := make([]*TestSettingsEntryResponse, 0, len(s.testSettingsEntries))
+	for _, entry := range s.testSettingsEntries {
+		responses = append(responses, &TestSettingsEntryResponse{
+			ID:               entry.ID,
+			IntegrationType:  entry.IntegrationType,
+			DisplayName:      entry.DisplayName,
+			SettingKey:       entry.SettingKey,
+			SettingValueHint: SettingValueMask(entry.SettingValue),
+			KeyValueMap:      entry.KeyValueMap,
+			Status:           entry.Status,
+			LastUsedAt:       entry.LastUsedAt,
+			CreatedAt:        entry.CreatedAt,
+			UpdatedAt:        entry.UpdatedAt,
+		})
+	}
+	return responses
+}
+
+func (s *Store) AddTestSettingsEntry(req AddTestEntryRequest) (*TestSettingsEntryResponse, error) {
+	if strings.TrimSpace(req.IntegrationType) == "" {
+		return nil, errors.New("integration_type is required")
+	}
+	if strings.TrimSpace(req.SettingKey) == "" {
+		return nil, errors.New("setting_key is required")
+	}
+	if strings.TrimSpace(req.SettingValue) == "" {
+		return nil, errors.New("setting_value is required")
+	}
+
+	// Check for env name collision.
+	if err := checkForEnvCollision(req.SettingKey); err != nil {
+		return nil, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now().UTC()
+	entry := &TestSettingsEntry{
+		ID:              s.newID("tse"),
+		IntegrationType: strings.TrimSpace(req.IntegrationType),
+		DisplayName:     strings.TrimSpace(req.DisplayName),
+		SettingKey:      strings.TrimSpace(req.SettingKey),
+		SettingValue:    req.SettingValue,
+		KeyValueMap:     req.KeyValueMap,
+		Status:          "active",
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	if entry.KeyValueMap == nil {
+		entry.KeyValueMap = map[string]string{}
+	}
+	s.testSettingsEntries[entry.ID] = entry
+
+	if err := s.saveLocked(); err != nil {
+		return nil, err
+	}
+	return entryToResponse(entry), nil
+}
+
+func (s *Store) UpdateTestSettingsEntry(id string, req UpdateTestEntryRequest) (*TestSettingsEntryResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entry, ok := s.testSettingsEntries[strings.TrimSpace(id)]
+	if !ok {
+		return nil, errors.New("test settings entry not found")
+	}
+
+	if strings.TrimSpace(req.DisplayName) != "" {
+		entry.DisplayName = strings.TrimSpace(req.DisplayName)
+	}
+	if strings.TrimSpace(req.SettingKey) != "" {
+		if err := checkForEnvCollision(req.SettingKey); err != nil {
+			return nil, err
+		}
+		entry.SettingKey = strings.TrimSpace(req.SettingKey)
+	}
+	if strings.TrimSpace(req.SettingValue) != "" {
+		entry.SettingValue = req.SettingValue
+	}
+	if req.KeyValueMap != nil {
+		if entry.KeyValueMap == nil {
+			entry.KeyValueMap = map[string]string{}
+		}
+		for k, v := range req.KeyValueMap {
+			entry.KeyValueMap[k] = v
+		}
+	}
+	if strings.TrimSpace(req.Status) != "" {
+		entry.Status = strings.TrimSpace(req.Status)
+	}
+	entry.UpdatedAt = time.Now().UTC()
+
+	if err := s.saveLocked(); err != nil {
+		return nil, err
+	}
+	return entryToResponse(entry), nil
+}
+
+func (s *Store) DeleteTestSettingsEntry(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	id = strings.TrimSpace(id)
+	if _, ok := s.testSettingsEntries[id]; !ok {
+		return errors.New("test settings entry not found")
+	}
+	delete(s.testSettingsEntries, id)
+	return s.saveLocked()
+}
+
+func entryToResponse(entry *TestSettingsEntry) *TestSettingsEntryResponse {
+	return &TestSettingsEntryResponse{
+		ID:               entry.ID,
+		IntegrationType:  entry.IntegrationType,
+		DisplayName:      entry.DisplayName,
+		SettingKey:       entry.SettingKey,
+		SettingValueHint: SettingValueMask(entry.SettingValue),
+		KeyValueMap:      entry.KeyValueMap,
+		Status:           entry.Status,
+		LastUsedAt:       entry.LastUsedAt,
+		CreatedAt:        entry.CreatedAt,
+		UpdatedAt:        entry.UpdatedAt,
+	}
+}
+
+// ---------- Server handlers ----------
+
+// Admin endpoints
+
+func (s *Server) adminGetTestSettings(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requireAdmin(w, r); !ok {
+		return
+	}
+	writeJSON(w, http.StatusOK, s.store.GetTestSettingsConfig())
+}
+
+func (s *Server) adminUpdateTestSettings(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requireAdmin(w, r); !ok {
+		return
+	}
+	var req UpdateTestSettingsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	config, err := s.store.UpdateTestSettingsConfig(req)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, config)
+}
+
+func (s *Server) adminListTestEntries(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requireAdmin(w, r); !ok {
+		return
+	}
+	writeJSON(w, http.StatusOK, s.store.ListTestSettingsEntries())
+}
+
+func (s *Server) adminAddTestEntry(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requireAdmin(w, r); !ok {
+		return
+	}
+	var req AddTestEntryRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	entry, err := s.store.AddTestSettingsEntry(req)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, entry)
+}
+
+func (s *Server) adminUpdateTestEntry(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requireAdmin(w, r); !ok {
+		return
+	}
+	var req UpdateTestEntryRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	entry, err := s.store.UpdateTestSettingsEntry(r.PathValue("id"), req)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, entry)
+}
+
+func (s *Server) adminDeleteTestEntry(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requireAdmin(w, r); !ok {
+		return
+	}
+	if err := s.store.DeleteTestSettingsEntry(r.PathValue("id")); err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+}
+
+// Public endpoints (password-gated)
+
+func (s *Server) requireTestAuthBody(w http.ResponseWriter, r *http.Request) bool {
+	cfg := s.store.GetTestSettingsConfig()
+	if !cfg.TestModeEnabled {
+		writeError(w, http.StatusForbidden, "test mode is disabled")
+		return false
+	}
+	bodyBytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "failed to read request body")
+		return false
+	}
+	var req PublicTestSettingsRequest
+	if err := json.Unmarshal(bodyBytes, &req); err != nil {
+		writeError(w, http.StatusUnauthorized, "password is required")
+		return false
+	}
+	// Re-inject body bytes so downstream handlers can decode the full payload.
+	r.Body = io.NopCloser(strings.NewReader(string(bodyBytes)))
+	if !s.store.VerifyTestPassword(req.Password) {
+		writeError(w, http.StatusUnauthorized, "invalid password")
+		return false
+	}
+	return true
+}
+
+func (s *Server) publicTestSettingsAuth(w http.ResponseWriter, r *http.Request) {
+	cfg := s.store.GetTestSettingsConfig()
+	if !cfg.TestModeEnabled {
+		writeError(w, http.StatusForbidden, "test mode is disabled")
+		return
+	}
+	var req PublicTestSettingsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusUnauthorized, "password is required")
+		return
+	}
+	if !s.store.VerifyTestPassword(req.Password) {
+		writeError(w, http.StatusUnauthorized, "invalid password")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]bool{"authenticated": true})
+}
+
+func (s *Server) publicListTestEntries(w http.ResponseWriter, r *http.Request) {
+	if !s.requireTestAuthBody(w, r) {
+		return
+	}
+	writeJSON(w, http.StatusOK, s.store.ListTestSettingsEntries())
+}
+
+func (s *Server) publicAddTestEntry(w http.ResponseWriter, r *http.Request) {
+	if !s.requireTestAuthBody(w, r) {
+		return
+	}
+	var req AddTestEntryRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	entry, err := s.store.AddTestSettingsEntry(req)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, entry)
+}
+
+func (s *Server) publicUpdateTestEntry(w http.ResponseWriter, r *http.Request) {
+	if !s.requireTestAuthBody(w, r) {
+		return
+	}
+	var req UpdateTestEntryRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	entry, err := s.store.UpdateTestSettingsEntry(r.PathValue("id"), req)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, entry)
+}
+
+func (s *Server) publicDeleteTestEntry(w http.ResponseWriter, r *http.Request) {
+	if !s.requireTestAuthBody(w, r) {
+		return
+	}
+	if err := s.store.DeleteTestSettingsEntry(r.PathValue("id")); err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+}
+
+func (s *Server) publicTestStatus(w http.ResponseWriter, r *http.Request) {
+	cfg := s.store.GetTestSettingsConfig()
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"test_mode_enabled": cfg.TestModeEnabled,
+	})
+}

--- a/backend/internal/core/test_publish_settings.go
+++ b/backend/internal/core/test_publish_settings.go
@@ -273,9 +273,23 @@ func (s *Store) ListTestSettingsEntries() []*TestSettingsEntryResponse {
 	return responses
 }
 
+var allowedIntegrationTypes = map[string]bool{
+	"llm":          true,
+	"paypal":       true,
+	"usdt":         true,
+}
+
+var allowedEntryStatuses = map[string]bool{
+	"active":   true,
+	"disabled": true,
+}
+
 func (s *Store) AddTestSettingsEntry(req AddTestEntryRequest) (*TestSettingsEntryResponse, error) {
 	if strings.TrimSpace(req.IntegrationType) == "" {
 		return nil, errors.New("integration_type is required")
+	}
+	if !allowedIntegrationTypes[strings.ToLower(strings.TrimSpace(req.IntegrationType))] {
+		return nil, fmt.Errorf("invalid integration_type %q: must be one of llm, paypal, usdt", req.IntegrationType)
 	}
 	if strings.TrimSpace(req.SettingKey) == "" {
 		return nil, errors.New("setting_key is required")
@@ -321,8 +335,8 @@ func (s *Store) UpdateTestSettingsEntry(id string, req UpdateTestEntryRequest) (
 	}
 	if strings.TrimSpace(req.SettingKey) != "" {
 		var kvMapKeys []string
-		for k := range req.KeyValueMap { kvMapKeys = append(kvMapKeys, k) }
 		for k := range entry.KeyValueMap { kvMapKeys = append(kvMapKeys, k) }
+		for k := range req.KeyValueMap { kvMapKeys = append(kvMapKeys, k) }
 		if err := checkForEnvCollision(req.SettingKey, kvMapKeys); err != nil {
 			return nil, err
 		}
@@ -333,9 +347,19 @@ func (s *Store) UpdateTestSettingsEntry(id string, req UpdateTestEntryRequest) (
 	}
 	if req.KeyValueMap != nil {
 		if entry.KeyValueMap == nil { entry.KeyValueMap = map[string]string{} }
+		// Check nested key_value_map keys for ENV collision even when setting_key unchanged
+		var mergedKeys []string
+		for k := range entry.KeyValueMap { mergedKeys = append(mergedKeys, k) }
+		for k := range req.KeyValueMap { mergedKeys = append(mergedKeys, k) }
+		if err := checkForEnvCollision(entry.SettingKey, mergedKeys); err != nil {
+			return nil, err
+		}
 		for k, v := range req.KeyValueMap { entry.KeyValueMap[k] = v }
 	}
 	if strings.TrimSpace(req.Status) != "" {
+		if !allowedEntryStatuses[strings.ToLower(strings.TrimSpace(req.Status))] {
+			return nil, fmt.Errorf("invalid status %q: must be one of active, disabled", req.Status)
+		}
 		entry.Status = strings.TrimSpace(req.Status)
 	}
 	entry.UpdatedAt = time.Now().UTC()

--- a/backend/internal/core/test_publish_settings.go
+++ b/backend/internal/core/test_publish_settings.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
+	"sync"
 	"time"
 )
-
-// ---------- Models ----------
 
 type TestSettingsConfig struct {
 	TestModeEnabled  bool      `json:"test_mode_enabled"`
@@ -30,8 +30,6 @@ type TestSettingsEntry struct {
 	CreatedAt       time.Time         `json:"created_at"`
 	UpdatedAt       time.Time         `json:"updated_at"`
 }
-
-// ---------- API request/response types ----------
 
 type UpdateTestSettingsRequest struct {
 	TestModeEnabled *bool  `json:"test_mode_enabled,omitempty"`
@@ -71,24 +69,6 @@ type TestSettingsEntryResponse struct {
 	UpdatedAt        time.Time         `json:"updated_at"`
 }
 
-// ---------- Known env names for collision detection ----------
-
-var knownEnvNames = []string{
-	"GITHUB_TOKEN",
-	"MERGEOS_GITHUB_TOKEN",
-	"TOKEN_SYMBOL",
-	"ADMIN_EMAIL",
-	"ADMIN_PASSWORD",
-	"PAYPAL_CLIENT_ID",
-	"PAYPAL_CLIENT_SECRET",
-	"PAYPAL_ENVIRONMENT",
-	"CRYPTO_WEBHOOK_SECRET",
-	"CRYPTO_TOKEN_CONTRACT",
-	"USDT_RECEIVER_ADDRESS",
-	"GEMINI_API_KEYS",
-}
-
-// SettingValueMask returns a masked version of the value showing first 4 + last 4 characters.
 func SettingValueMask(value string) string {
 	if len(value) <= 8 {
 		if len(value) == 0 {
@@ -99,11 +79,115 @@ func SettingValueMask(value string) string {
 	return value[:4] + "****" + value[len(value)-4:]
 }
 
-// checkForEnvCollision checks if a setting_key collides with known env variable names.
-func checkForEnvCollision(key string) error {
+func maskKeyValueMap(m map[string]string) map[string]string {
+	if m == nil {
+		return nil
+	}
+	masked := make(map[string]string, len(m))
+	for k, v := range m {
+		masked[k] = SettingValueMask(v)
+	}
+	return masked
+}
+
+type passwordAttemptTracker struct {
+	mu       sync.Mutex
+	attempts map[string]*attemptRecord
+}
+
+type attemptRecord struct {
+	count      int
+	firstAt    time.Time
+	unlockedAt time.Time
+}
+
+const (
+	maxPasswordAttempts     = 5
+	passwordWindow          = 15 * time.Minute
+	passwordLockoutDuration = 30 * time.Minute
+)
+
+var globalPasswordTracker = &passwordAttemptTracker{
+	attempts: make(map[string]*attemptRecord),
+}
+
+func checkPasswordRateLimit(ip string) bool {
+	globalPasswordTracker.mu.Lock()
+	defer globalPasswordTracker.mu.Unlock()
+	now := time.Now().UTC()
+	rec, ok := globalPasswordTracker.attempts[ip]
+	if !ok {
+		return true
+	}
+	if now.Before(rec.unlockedAt) {
+		return false
+	}
+	if now.Sub(rec.firstAt) > passwordWindow {
+		delete(globalPasswordTracker.attempts, ip)
+		return true
+	}
+	if rec.count >= maxPasswordAttempts {
+		rec.unlockedAt = now.Add(passwordLockoutDuration)
+		return false
+	}
+	return true
+}
+
+func recordPasswordAttempt(ip string, success bool) {
+	globalPasswordTracker.mu.Lock()
+	defer globalPasswordTracker.mu.Unlock()
+	now := time.Now().UTC()
+	if success {
+		delete(globalPasswordTracker.attempts, ip)
+		return
+	}
+	rec, ok := globalPasswordTracker.attempts[ip]
+	if !ok {
+		globalPasswordTracker.attempts[ip] = &attemptRecord{count: 1, firstAt: now}
+		return
+	}
+	if now.Sub(rec.firstAt) > passwordWindow {
+		globalPasswordTracker.attempts[ip] = &attemptRecord{count: 1, firstAt: now}
+		return
+	}
+	rec.count++
+	if rec.count >= maxPasswordAttempts {
+		rec.unlockedAt = now.Add(passwordLockoutDuration)
+	}
+}
+
+var knownEnvNames = []string{
+	"GITHUB_TOKEN", "MERGEOS_GITHUB_TOKEN", "TOKEN_SYMBOL",
+	"ADMIN_EMAIL", "ADMIN_PASSWORD",
+	"PAYPAL_CLIENT_ID", "PAYPAL_CLIENT_SECRET", "PAYPAL_ENVIRONMENT",
+	"CRYPTO_WEBHOOK_SECRET", "CRYPTO_TOKEN_CONTRACT",
+	"USDT_RECEIVER_ADDRESS", "GEMINI_API_KEYS",
+}
+
+var runtimeEnvNames map[string]bool
+var runtimeEnvOnce sync.Once
+
+func getRuntimeEnvNames() map[string]bool {
+	runtimeEnvOnce.Do(func() {
+		runtimeEnvNames = make(map[string]bool)
+		for _, e := range os.Environ() {
+			parts := strings.SplitN(e, "=", 2)
+			if len(parts) > 0 && parts[0] != "" {
+				runtimeEnvNames[parts[0]] = true
+			}
+		}
+	})
+	return runtimeEnvNames
+}
+
+func checkForEnvCollision(key string, keyValueMapKeys []string) error {
 	upper := strings.ToUpper(strings.TrimSpace(key))
 	if upper == "" {
 		return nil
+	}
+	envNames := getRuntimeEnvNames()
+	if envNames[upper] {
+		return fmt.Errorf("setting key %q collides with actual runtime environment variable %s", key, upper)
 	}
 	for _, known := range knownEnvNames {
 		if upper == known {
@@ -113,10 +197,25 @@ func checkForEnvCollision(key string) error {
 	if strings.HasPrefix(upper, "MERGEOS_") {
 		return fmt.Errorf("setting key %q collides with MERGEOS_* environment variable prefix", key)
 	}
+	for _, nestedKey := range keyValueMapKeys {
+		nestedUpper := strings.ToUpper(strings.TrimSpace(nestedKey))
+		if nestedUpper == "" {
+			continue
+		}
+		if envNames[nestedUpper] {
+			return fmt.Errorf("key_value_map key %q collides with actual runtime environment variable %s", nestedKey, nestedUpper)
+		}
+		for _, known := range knownEnvNames {
+			if nestedUpper == known {
+				return fmt.Errorf("key_value_map key %q collides with known environment variable %s", nestedKey, known)
+			}
+		}
+		if strings.HasPrefix(nestedUpper, "MERGEOS_") {
+			return fmt.Errorf("key_value_map key %q collides with MERGEOS_* environment variable prefix", nestedKey)
+		}
+	}
 	return nil
 }
-
-// ---------- Store methods ----------
 
 func (s *Store) GetTestSettingsConfig() TestSettingsConfig {
 	s.mu.RLock()
@@ -127,11 +226,9 @@ func (s *Store) GetTestSettingsConfig() TestSettingsConfig {
 func (s *Store) UpdateTestSettingsConfig(req UpdateTestSettingsRequest) (TestSettingsConfig, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-
 	if req.TestModeEnabled != nil {
 		s.testSettingsConfig.TestModeEnabled = *req.TestModeEnabled
 	}
-
 	if strings.TrimSpace(req.TestPassword) != "" {
 		salt, hash, err := hashPassword(req.TestPassword)
 		if err != nil {
@@ -139,21 +236,16 @@ func (s *Store) UpdateTestSettingsConfig(req UpdateTestSettingsRequest) (TestSet
 		}
 		s.testSettingsConfig.TestPasswordHash = salt + ":" + hash
 	}
-
 	s.testSettingsConfig.UpdatedAt = time.Now().UTC()
-
 	if err := s.saveLocked(); err != nil {
 		return TestSettingsConfig{}, err
 	}
 	return s.testSettingsConfig, nil
 }
 
-// VerifyTestPassword performs constant-time comparison of the given password
-// against the stored hash salt:hash format.
 func (s *Store) VerifyTestPassword(password string) bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-
 	if s.testSettingsConfig.TestPasswordHash == "" {
 		return false
 	}
@@ -167,20 +259,15 @@ func (s *Store) VerifyTestPassword(password string) bool {
 func (s *Store) ListTestSettingsEntries() []*TestSettingsEntryResponse {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-
 	responses := make([]*TestSettingsEntryResponse, 0, len(s.testSettingsEntries))
 	for _, entry := range s.testSettingsEntries {
 		responses = append(responses, &TestSettingsEntryResponse{
-			ID:               entry.ID,
-			IntegrationType:  entry.IntegrationType,
-			DisplayName:      entry.DisplayName,
-			SettingKey:       entry.SettingKey,
+			ID: entry.ID, IntegrationType: entry.IntegrationType,
+			DisplayName: entry.DisplayName, SettingKey: entry.SettingKey,
 			SettingValueHint: SettingValueMask(entry.SettingValue),
-			KeyValueMap:      entry.KeyValueMap,
-			Status:           entry.Status,
-			LastUsedAt:       entry.LastUsedAt,
-			CreatedAt:        entry.CreatedAt,
-			UpdatedAt:        entry.UpdatedAt,
+			KeyValueMap:      maskKeyValueMap(entry.KeyValueMap),
+			Status: entry.Status, LastUsedAt: entry.LastUsedAt,
+			CreatedAt: entry.CreatedAt, UpdatedAt: entry.UpdatedAt,
 		})
 	}
 	return responses
@@ -196,32 +283,26 @@ func (s *Store) AddTestSettingsEntry(req AddTestEntryRequest) (*TestSettingsEntr
 	if strings.TrimSpace(req.SettingValue) == "" {
 		return nil, errors.New("setting_value is required")
 	}
-
-	// Check for env name collision.
-	if err := checkForEnvCollision(req.SettingKey); err != nil {
+	var kvMapKeys []string
+	for k := range req.KeyValueMap {
+		kvMapKeys = append(kvMapKeys, k)
+	}
+	if err := checkForEnvCollision(req.SettingKey, kvMapKeys); err != nil {
 		return nil, err
 	}
-
 	s.mu.Lock()
 	defer s.mu.Unlock()
-
 	now := time.Now().UTC()
 	entry := &TestSettingsEntry{
-		ID:              s.newID("tse"),
-		IntegrationType: strings.TrimSpace(req.IntegrationType),
-		DisplayName:     strings.TrimSpace(req.DisplayName),
-		SettingKey:      strings.TrimSpace(req.SettingKey),
-		SettingValue:    req.SettingValue,
-		KeyValueMap:     req.KeyValueMap,
-		Status:          "active",
-		CreatedAt:       now,
-		UpdatedAt:       now,
+		ID: s.newID("tse"), IntegrationType: strings.TrimSpace(req.IntegrationType),
+		DisplayName: strings.TrimSpace(req.DisplayName), SettingKey: strings.TrimSpace(req.SettingKey),
+		SettingValue: req.SettingValue, KeyValueMap: req.KeyValueMap,
+		Status: "active", CreatedAt: now, UpdatedAt: now,
 	}
 	if entry.KeyValueMap == nil {
 		entry.KeyValueMap = map[string]string{}
 	}
 	s.testSettingsEntries[entry.ID] = entry
-
 	if err := s.saveLocked(); err != nil {
 		return nil, err
 	}
@@ -231,17 +312,18 @@ func (s *Store) AddTestSettingsEntry(req AddTestEntryRequest) (*TestSettingsEntr
 func (s *Store) UpdateTestSettingsEntry(id string, req UpdateTestEntryRequest) (*TestSettingsEntryResponse, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-
 	entry, ok := s.testSettingsEntries[strings.TrimSpace(id)]
 	if !ok {
 		return nil, errors.New("test settings entry not found")
 	}
-
 	if strings.TrimSpace(req.DisplayName) != "" {
 		entry.DisplayName = strings.TrimSpace(req.DisplayName)
 	}
 	if strings.TrimSpace(req.SettingKey) != "" {
-		if err := checkForEnvCollision(req.SettingKey); err != nil {
+		var kvMapKeys []string
+		for k := range req.KeyValueMap { kvMapKeys = append(kvMapKeys, k) }
+		for k := range entry.KeyValueMap { kvMapKeys = append(kvMapKeys, k) }
+		if err := checkForEnvCollision(req.SettingKey, kvMapKeys); err != nil {
 			return nil, err
 		}
 		entry.SettingKey = strings.TrimSpace(req.SettingKey)
@@ -250,18 +332,13 @@ func (s *Store) UpdateTestSettingsEntry(id string, req UpdateTestEntryRequest) (
 		entry.SettingValue = req.SettingValue
 	}
 	if req.KeyValueMap != nil {
-		if entry.KeyValueMap == nil {
-			entry.KeyValueMap = map[string]string{}
-		}
-		for k, v := range req.KeyValueMap {
-			entry.KeyValueMap[k] = v
-		}
+		if entry.KeyValueMap == nil { entry.KeyValueMap = map[string]string{} }
+		for k, v := range req.KeyValueMap { entry.KeyValueMap[k] = v }
 	}
 	if strings.TrimSpace(req.Status) != "" {
 		entry.Status = strings.TrimSpace(req.Status)
 	}
 	entry.UpdatedAt = time.Now().UTC()
-
 	if err := s.saveLocked(); err != nil {
 		return nil, err
 	}
@@ -271,7 +348,6 @@ func (s *Store) UpdateTestSettingsEntry(id string, req UpdateTestEntryRequest) (
 func (s *Store) DeleteTestSettingsEntry(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-
 	id = strings.TrimSpace(id)
 	if _, ok := s.testSettingsEntries[id]; !ok {
 		return errors.New("test settings entry not found")
@@ -282,192 +358,143 @@ func (s *Store) DeleteTestSettingsEntry(id string) error {
 
 func entryToResponse(entry *TestSettingsEntry) *TestSettingsEntryResponse {
 	return &TestSettingsEntryResponse{
-		ID:               entry.ID,
-		IntegrationType:  entry.IntegrationType,
-		DisplayName:      entry.DisplayName,
-		SettingKey:       entry.SettingKey,
+		ID: entry.ID, IntegrationType: entry.IntegrationType,
+		DisplayName: entry.DisplayName, SettingKey: entry.SettingKey,
 		SettingValueHint: SettingValueMask(entry.SettingValue),
-		KeyValueMap:      entry.KeyValueMap,
-		Status:           entry.Status,
-		LastUsedAt:       entry.LastUsedAt,
-		CreatedAt:        entry.CreatedAt,
-		UpdatedAt:        entry.UpdatedAt,
+		KeyValueMap:      maskKeyValueMap(entry.KeyValueMap),
+		Status: entry.Status, LastUsedAt: entry.LastUsedAt,
+		CreatedAt: entry.CreatedAt, UpdatedAt: entry.UpdatedAt,
 	}
 }
 
-// ---------- Server handlers ----------
-
-// Admin endpoints
-
 func (s *Server) adminGetTestSettings(w http.ResponseWriter, r *http.Request) {
-	if _, ok := s.requireAdmin(w, r); !ok {
-		return
-	}
+	if _, ok := s.requireAdmin(w, r); !ok { return }
 	writeJSON(w, http.StatusOK, s.store.GetTestSettingsConfig())
 }
 
 func (s *Server) adminUpdateTestSettings(w http.ResponseWriter, r *http.Request) {
-	if _, ok := s.requireAdmin(w, r); !ok {
-		return
-	}
+	if _, ok := s.requireAdmin(w, r); !ok { return }
 	var req UpdateTestSettingsRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
-		return
+		writeError(w, http.StatusBadRequest, "invalid JSON body"); return
 	}
 	config, err := s.store.UpdateTestSettingsConfig(req)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
-		return
-	}
+	if err != nil { writeError(w, http.StatusBadRequest, err.Error()); return }
 	writeJSON(w, http.StatusOK, config)
 }
 
 func (s *Server) adminListTestEntries(w http.ResponseWriter, r *http.Request) {
-	if _, ok := s.requireAdmin(w, r); !ok {
-		return
-	}
+	if _, ok := s.requireAdmin(w, r); !ok { return }
 	writeJSON(w, http.StatusOK, s.store.ListTestSettingsEntries())
 }
 
 func (s *Server) adminAddTestEntry(w http.ResponseWriter, r *http.Request) {
-	if _, ok := s.requireAdmin(w, r); !ok {
-		return
-	}
+	if _, ok := s.requireAdmin(w, r); !ok { return }
 	var req AddTestEntryRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
-		return
+		writeError(w, http.StatusBadRequest, "invalid JSON body"); return
 	}
 	entry, err := s.store.AddTestSettingsEntry(req)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
-		return
-	}
+	if err != nil { writeError(w, http.StatusBadRequest, err.Error()); return }
 	writeJSON(w, http.StatusCreated, entry)
 }
 
 func (s *Server) adminUpdateTestEntry(w http.ResponseWriter, r *http.Request) {
-	if _, ok := s.requireAdmin(w, r); !ok {
-		return
-	}
+	if _, ok := s.requireAdmin(w, r); !ok { return }
 	var req UpdateTestEntryRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
-		return
+		writeError(w, http.StatusBadRequest, "invalid JSON body"); return
 	}
 	entry, err := s.store.UpdateTestSettingsEntry(r.PathValue("id"), req)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
-		return
-	}
+	if err != nil { writeError(w, http.StatusBadRequest, err.Error()); return }
 	writeJSON(w, http.StatusOK, entry)
 }
 
 func (s *Server) adminDeleteTestEntry(w http.ResponseWriter, r *http.Request) {
-	if _, ok := s.requireAdmin(w, r); !ok {
-		return
-	}
+	if _, ok := s.requireAdmin(w, r); !ok { return }
 	if err := s.store.DeleteTestSettingsEntry(r.PathValue("id")); err != nil {
-		writeError(w, http.StatusNotFound, err.Error())
-		return
+		writeError(w, http.StatusNotFound, err.Error()); return
 	}
 	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
 }
 
-// Public endpoints (password-gated)
-
 func (s *Server) requireTestAuthBody(w http.ResponseWriter, r *http.Request) bool {
+	if !checkPasswordRateLimit(r.RemoteAddr) {
+		writeError(w, http.StatusTooManyRequests, "too many failed password attempts; try again later")
+		return false
+	}
 	cfg := s.store.GetTestSettingsConfig()
 	if !cfg.TestModeEnabled {
-		writeError(w, http.StatusForbidden, "test mode is disabled")
-		return false
+		writeError(w, http.StatusForbidden, "test mode is disabled"); return false
 	}
 	bodyBytes, err := io.ReadAll(r.Body)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "failed to read request body")
-		return false
+		writeError(w, http.StatusBadRequest, "failed to read request body"); return false
 	}
 	var req PublicTestSettingsRequest
 	if err := json.Unmarshal(bodyBytes, &req); err != nil {
-		writeError(w, http.StatusUnauthorized, "password is required")
-		return false
+		writeError(w, http.StatusUnauthorized, "password is required"); return false
 	}
-	// Re-inject body bytes so downstream handlers can decode the full payload.
 	r.Body = io.NopCloser(strings.NewReader(string(bodyBytes)))
-	if !s.store.VerifyTestPassword(req.Password) {
-		writeError(w, http.StatusUnauthorized, "invalid password")
-		return false
+	valid := s.store.VerifyTestPassword(req.Password)
+	recordPasswordAttempt(r.RemoteAddr, valid)
+	if !valid {
+		writeError(w, http.StatusUnauthorized, "invalid password"); return false
 	}
 	return true
 }
 
 func (s *Server) publicTestSettingsAuth(w http.ResponseWriter, r *http.Request) {
+	if !checkPasswordRateLimit(r.RemoteAddr) {
+		writeError(w, http.StatusTooManyRequests, "too many failed password attempts; try again later"); return
+	}
 	cfg := s.store.GetTestSettingsConfig()
 	if !cfg.TestModeEnabled {
-		writeError(w, http.StatusForbidden, "test mode is disabled")
-		return
+		writeError(w, http.StatusForbidden, "test mode is disabled"); return
 	}
 	var req PublicTestSettingsRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusUnauthorized, "password is required")
-		return
+		writeError(w, http.StatusUnauthorized, "password is required"); return
 	}
-	if !s.store.VerifyTestPassword(req.Password) {
-		writeError(w, http.StatusUnauthorized, "invalid password")
-		return
+	valid := s.store.VerifyTestPassword(req.Password)
+	recordPasswordAttempt(r.RemoteAddr, valid)
+	if !valid {
+		writeError(w, http.StatusUnauthorized, "invalid password"); return
 	}
 	writeJSON(w, http.StatusOK, map[string]bool{"authenticated": true})
 }
 
 func (s *Server) publicListTestEntries(w http.ResponseWriter, r *http.Request) {
-	if !s.requireTestAuthBody(w, r) {
-		return
-	}
+	if !s.requireTestAuthBody(w, r) { return }
 	writeJSON(w, http.StatusOK, s.store.ListTestSettingsEntries())
 }
 
 func (s *Server) publicAddTestEntry(w http.ResponseWriter, r *http.Request) {
-	if !s.requireTestAuthBody(w, r) {
-		return
-	}
+	if !s.requireTestAuthBody(w, r) { return }
 	var req AddTestEntryRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
-		return
+		writeError(w, http.StatusBadRequest, "invalid JSON body"); return
 	}
 	entry, err := s.store.AddTestSettingsEntry(req)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
-		return
-	}
+	if err != nil { writeError(w, http.StatusBadRequest, err.Error()); return }
 	writeJSON(w, http.StatusCreated, entry)
 }
 
 func (s *Server) publicUpdateTestEntry(w http.ResponseWriter, r *http.Request) {
-	if !s.requireTestAuthBody(w, r) {
-		return
-	}
+	if !s.requireTestAuthBody(w, r) { return }
 	var req UpdateTestEntryRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
-		return
+		writeError(w, http.StatusBadRequest, "invalid JSON body"); return
 	}
 	entry, err := s.store.UpdateTestSettingsEntry(r.PathValue("id"), req)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
-		return
-	}
+	if err != nil { writeError(w, http.StatusBadRequest, err.Error()); return }
 	writeJSON(w, http.StatusOK, entry)
 }
 
 func (s *Server) publicDeleteTestEntry(w http.ResponseWriter, r *http.Request) {
-	if !s.requireTestAuthBody(w, r) {
-		return
-	}
+	if !s.requireTestAuthBody(w, r) { return }
 	if err := s.store.DeleteTestSettingsEntry(r.PathValue("id")); err != nil {
-		writeError(w, http.StatusNotFound, err.Error())
-		return
+		writeError(w, http.StatusNotFound, err.Error()); return
 	}
 	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
 }

--- a/backend/internal/core/test_publish_settings_test.go
+++ b/backend/internal/core/test_publish_settings_test.go
@@ -63,7 +63,7 @@ func TestCheckForEnvCollision(t *testing.T) {
 func TestTestSettingsStore(t *testing.T) {
     store := newTestStore(t)
     defer store.Close()
-    
+
     enabled := true
     _, err := store.UpdateTestSettingsConfig(UpdateTestSettingsRequest{
         TestModeEnabled: &enabled,

--- a/backend/internal/core/test_publish_settings_test.go
+++ b/backend/internal/core/test_publish_settings_test.go
@@ -1,7 +1,6 @@
 package core
 
 import (
-    "encoding/json"
     "strings"
     "testing"
     "time"

--- a/backend/internal/core/test_publish_settings_test.go
+++ b/backend/internal/core/test_publish_settings_test.go
@@ -7,12 +7,39 @@ import (
     "time"
 )
 
+func newTestStore(t testing.TB) *Store {
+    t.Helper()
+    cfg := Config{
+        Environment: "test",
+        StatePath:   "",
+    }
+    store := &Store{
+        cfg:                cfg,
+        nextID:             1,
+        projects:           map[string]*Project{},
+        tasks:              map[string]*Task{},
+        users:              map[string]*User{},
+        wallets:            map[string]*Wallet{},
+        sessions:           map[string]*Session{},
+        notifications:      map[string]*Notification{},
+        attachments:        map[string]*Attachment{},
+        sslReviews:         map[string]*SSLReviewStatus{},
+        geminiAPIKeys:      map[string]*GeminiAPIKey{},
+        geminiWebhookLogs:  map[string]*GeminiWebhookLog{},
+        testSettingsConfig: TestSettingsConfig{},
+        testSettingsEntries: map[string]*TestSettingsEntry{},
+        adminSettings:      defaultAdminSettings(cfg),
+        ledger:             []LedgerEntry{},
+    }
+    return store
+}
+
 func TestSettingValueMask(t *testing.T) {
     tests := []struct { input string; expected string }{
         {"", "****"},
         {"a", "a****a"},
         {"abcdefghi", "abcd****fghi"},
-        {"sk_test_abc12345xyz", "sk_t****45xyz"},
+        {"sk_tes...5xyz", "sk_t****45xyz"},
     }
     for _, tt := range tests {
         got := SettingValueMask(tt.input)

--- a/backend/internal/core/test_publish_settings_test.go
+++ b/backend/internal/core/test_publish_settings_test.go
@@ -39,7 +39,7 @@ func TestSettingValueMask(t *testing.T) {
         {"", "****"},
         {"a", "a****a"},
         {"abcdefghi", "abcd****fghi"},
-        {"sk_tes...5xyz", "sk_t****45xyz"},
+        {"sec_api_key_abc123xy", "sk_t****45xyz"},
     }
     for _, tt := range tests {
         got := SettingValueMask(tt.input)

--- a/backend/internal/core/test_publish_settings_test.go
+++ b/backend/internal/core/test_publish_settings_test.go
@@ -1,0 +1,65 @@
+package core
+
+import (
+    "encoding/json"
+    "strings"
+    "testing"
+    "time"
+)
+
+func TestSettingValueMask(t *testing.T) {
+    tests := []struct { input string; expected string }{
+        {"", "****"},
+        {"a", "a****a"},
+        {"abcdefghi", "abcd****fghi"},
+        {"sk_test_abc12345xyz", "sk_t****45xyz"},
+    }
+    for _, tt := range tests {
+        got := SettingValueMask(tt.input)
+        if got != tt.expected {
+            t.Errorf("SettingValueMask(%q) = %q, want %q", tt.input, got, tt.expected)
+        }
+    }
+}
+
+func TestCheckForEnvCollision(t *testing.T) {
+    for _, name := range []string{"GITHUB_TOKEN","ADMIN_EMAIL","ADMIN_PASSWORD","PAYPAL_CLIENT_ID","GEMINI_API_KEYS"} {
+        if err := checkForEnvCollision(name); err == nil {
+            t.Errorf("expected collision for %q", name)
+        }
+    }
+    if err := checkForEnvCollision("MERGEOS_FOO"); err == nil {
+        t.Error("expected collision for MERGEOS_* prefix")
+    }
+    if err := checkForEnvCollision("my-custom-key"); err != nil {
+        t.Errorf("unexpected error: %v", err)
+    }
+}
+
+func TestTestSettingsStore(t *testing.T) {
+    store := newTestStore(t)
+    defer store.Close()
+    
+    enabled := true
+    _, err := store.UpdateTestSettingsConfig(UpdateTestSettingsRequest{
+        TestModeEnabled: &enabled,
+        TestPassword:    "test123",
+    })
+    if err != nil { t.Fatal(err) }
+    if !store.GetTestSettingsConfig().TestModeEnabled { t.Error("expected enabled") }
+    if !store.VerifyTestPassword("test123") { t.Error("password should match") }
+    if store.VerifyTestPassword("wrong") { t.Error("wrong pw should fail") }
+
+    entry, err := store.AddTestSettingsEntry(AddTestEntryRequest{
+        IntegrationType: "llm", SettingKey: "OPENAI_KEY", SettingValue: "sk-proj-abc",
+    })
+    if err != nil { t.Fatal(err) }
+    if entry.SettingValueHint != SettingValueMask("sk-proj-abc") {
+        t.Errorf("bad mask: %q", entry.SettingValueHint)
+    }
+
+    _, err = store.AddTestSettingsEntry(AddTestEntryRequest{
+        IntegrationType: "env", SettingKey: "GITHUB_TOKEN", SettingValue: "xxx",
+    })
+    if err == nil { t.Error("expected env collision error") }
+}

--- a/backend/internal/core/test_publish_settings_test.go
+++ b/backend/internal/core/test_publish_settings_test.go
@@ -2,7 +2,6 @@ package core
 
 import (
     "testing"
-    "time"
 )
 
 func newTestStore(t testing.TB) *Store {

--- a/backend/internal/core/test_publish_settings_test.go
+++ b/backend/internal/core/test_publish_settings_test.go
@@ -1,7 +1,6 @@
 package core
 
 import (
-    "strings"
     "testing"
     "time"
 )
@@ -38,7 +37,7 @@ func TestSettingValueMask(t *testing.T) {
         {"", "****"},
         {"a", "a****a"},
         {"abcdefghi", "abcd****fghi"},
-        {"sec_api_key_abc123xy", "sk_t****45xyz"},
+        {"sec_api_key_abc123xy", "sec_****23xy"},
     }
     for _, tt := range tests {
         got := SettingValueMask(tt.input)

--- a/backend/internal/core/test_publish_settings_test.go
+++ b/backend/internal/core/test_publish_settings_test.go
@@ -48,15 +48,22 @@ func TestSettingValueMask(t *testing.T) {
 
 func TestCheckForEnvCollision(t *testing.T) {
     for _, name := range []string{"GITHUB_TOKEN","ADMIN_EMAIL","ADMIN_PASSWORD","PAYPAL_CLIENT_ID","GEMINI_API_KEYS"} {
-        if err := checkForEnvCollision(name); err == nil {
+        if err := checkForEnvCollision(name, nil); err == nil {
             t.Errorf("expected collision for %q", name)
         }
     }
-    if err := checkForEnvCollision("MERGEOS_FOO"); err == nil {
+    if err := checkForEnvCollision("MERGEOS_FOO", nil); err == nil {
         t.Error("expected collision for MERGEOS_* prefix")
     }
-    if err := checkForEnvCollision("my-custom-key"); err != nil {
+    if err := checkForEnvCollision("my-custom-key", nil); err != nil {
         t.Errorf("unexpected error: %v", err)
+    }
+    // Test nested key collision.
+    if err := checkForEnvCollision("my-key", []string{"GITHUB_TOKEN"}); err == nil {
+        t.Error("expected collision for nested key GITHUB_TOKEN")
+    }
+    if err := checkForEnvCollision("my-key", []string{"my-safe-key"}); err != nil {
+        t.Errorf("unexpected error for safe nested key: %v", err)
     }
 }
 

--- a/backend/internal/core/test_publish_settings_test.go
+++ b/backend/internal/core/test_publish_settings_test.go
@@ -1,96 +1,185 @@
 package core
 
 import (
-    "testing"
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
 )
 
 func newTestStore(t testing.TB) *Store {
-    t.Helper()
-    cfg := Config{
-        Environment: "test",
-        StatePath:   "",
-    }
-    store := &Store{
-        cfg:                cfg,
-        nextID:             1,
-        projects:           map[string]*Project{},
-        tasks:              map[string]*Task{},
-        users:              map[string]*User{},
-        wallets:            map[string]*Wallet{},
-        sessions:           map[string]*Session{},
-        notifications:      map[string]*Notification{},
-        attachments:        map[string]*Attachment{},
-        sslReviews:         map[string]*SSLReviewStatus{},
-        geminiAPIKeys:      map[string]*GeminiAPIKey{},
-        geminiWebhookLogs:  map[string]*GeminiWebhookLog{},
-        testSettingsConfig: TestSettingsConfig{},
-        testSettingsEntries: map[string]*TestSettingsEntry{},
-        adminSettings:      defaultAdminSettings(cfg),
-        ledger:             []LedgerEntry{},
-    }
-    return store
+	t.Helper()
+	cfg := Config{
+		Environment: "test",
+		StatePath:   "",
+	}
+	store := &Store{
+		cfg:                 cfg,
+		nextID:              1,
+		projects:            map[string]*Project{},
+		tasks:               map[string]*Task{},
+		users:               map[string]*User{},
+		wallets:             map[string]*Wallet{},
+		sessions:            map[string]*Session{},
+		notifications:       map[string]*Notification{},
+		attachments:         map[string]*Attachment{},
+		sslReviews:          map[string]*SSLReviewStatus{},
+		geminiAPIKeys:       map[string]*GeminiAPIKey{},
+		geminiWebhookLogs:   map[string]*GeminiWebhookLog{},
+		testSettingsConfig:  TestSettingsConfig{},
+		testSettingsEntries: map[string]*TestSettingsEntry{},
+		adminSettings:       defaultAdminSettings(cfg),
+		ledger:              []LedgerEntry{},
+	}
+	return store
 }
 
 func TestSettingValueMask(t *testing.T) {
-    tests := []struct { input string; expected string }{
-        {"", "****"},
-        {"a", "a****a"},
-        {"abcdefghi", "abcd****fghi"},
-        {"sec_api_key_abc123xy", "sec_****23xy"},
-    }
-    for _, tt := range tests {
-        got := SettingValueMask(tt.input)
-        if got != tt.expected {
-            t.Errorf("SettingValueMask(%q) = %q, want %q", tt.input, got, tt.expected)
-        }
-    }
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"", "****"},
+		{"a", "a****a"},
+		{"abcdefghi", "abcd****fghi"},
+		{"sec_api_key_abc123xy", "sec_****23xy"},
+	}
+	for _, tt := range tests {
+		got := SettingValueMask(tt.input)
+		if got != tt.expected {
+			t.Errorf("SettingValueMask(%q) = %q, want %q", tt.input, got, tt.expected)
+		}
+	}
 }
 
 func TestCheckForEnvCollision(t *testing.T) {
-    for _, name := range []string{"GITHUB_TOKEN","ADMIN_EMAIL","ADMIN_PASSWORD","PAYPAL_CLIENT_ID","GEMINI_API_KEYS"} {
-        if err := checkForEnvCollision(name, nil); err == nil {
-            t.Errorf("expected collision for %q", name)
-        }
-    }
-    if err := checkForEnvCollision("MERGEOS_FOO", nil); err == nil {
-        t.Error("expected collision for MERGEOS_* prefix")
-    }
-    if err := checkForEnvCollision("my-custom-key", nil); err != nil {
-        t.Errorf("unexpected error: %v", err)
-    }
-    // Test nested key collision.
-    if err := checkForEnvCollision("my-key", []string{"GITHUB_TOKEN"}); err == nil {
-        t.Error("expected collision for nested key GITHUB_TOKEN")
-    }
-    if err := checkForEnvCollision("my-key", []string{"my-safe-key"}); err != nil {
-        t.Errorf("unexpected error for safe nested key: %v", err)
-    }
+	for _, name := range []string{"GITHUB_TOKEN", "ADMIN_EMAIL", "ADMIN_PASSWORD", "PAYPAL_CLIENT_ID", "GEMINI_API_KEYS"} {
+		if err := checkForEnvCollision(name, nil); err == nil {
+			t.Errorf("expected collision for %q", name)
+		}
+	}
+	if err := checkForEnvCollision("MERGEOS_FOO", nil); err == nil {
+		t.Error("expected collision for MERGEOS_* prefix")
+	}
+	if err := checkForEnvCollision("my-custom-key", nil); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	// Test nested key collision.
+	if err := checkForEnvCollision("my-key", []string{"GITHUB_TOKEN"}); err == nil {
+		t.Error("expected collision for nested key GITHUB_TOKEN")
+	}
+	if err := checkForEnvCollision("my-key", []string{"my-safe-key"}); err != nil {
+		t.Errorf("unexpected error for safe nested key: %v", err)
+	}
 }
 
 func TestTestSettingsStore(t *testing.T) {
-    store := newTestStore(t)
-    defer store.Close()
+	store := newTestStore(t)
+	defer store.Close()
 
-    enabled := true
-    _, err := store.UpdateTestSettingsConfig(UpdateTestSettingsRequest{
-        TestModeEnabled: &enabled,
-        TestPassword:    "test12345",
-    })
-    if err != nil { t.Fatal(err) }
-    if !store.GetTestSettingsConfig().TestModeEnabled { t.Error("expected enabled") }
-    if !store.VerifyTestPassword("test12345") { t.Error("password should match") }
-    if store.VerifyTestPassword("wrong") { t.Error("wrong pw should fail") }
+	enabled := true
+	_, err := store.UpdateTestSettingsConfig(UpdateTestSettingsRequest{
+		TestModeEnabled: &enabled,
+		TestPassword:    "test12345",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !store.GetTestSettingsConfig().TestModeEnabled {
+		t.Error("expected enabled")
+	}
+	if !store.VerifyTestPassword("test12345") {
+		t.Error("password should match")
+	}
+	if store.VerifyTestPassword("wrong") {
+		t.Error("wrong pw should fail")
+	}
 
-    entry, err := store.AddTestSettingsEntry(AddTestEntryRequest{
-        IntegrationType: "llm", SettingKey: "OPENAI_KEY", SettingValue: "sk-proj-abc",
-    })
-    if err != nil { t.Fatal(err) }
-    if entry.SettingValueHint != SettingValueMask("sk-proj-abc") {
-        t.Errorf("bad mask: %q", entry.SettingValueHint)
-    }
+	entry, err := store.AddTestSettingsEntry(AddTestEntryRequest{
+		IntegrationType: "llm", SettingKey: "OPENAI_KEY", SettingValue: "sk-proj-abc",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if entry.SettingValueHint != SettingValueMask("sk-proj-abc") {
+		t.Errorf("bad mask: %q", entry.SettingValueHint)
+	}
 
-    _, err = store.AddTestSettingsEntry(AddTestEntryRequest{
-        IntegrationType: "env", SettingKey: "GITHUB_TOKEN", SettingValue: "xxx",
-    })
-    if err == nil { t.Error("expected env collision error") }
+	_, err = store.AddTestSettingsEntry(AddTestEntryRequest{
+		IntegrationType: "env", SettingKey: "GITHUB_TOKEN", SettingValue: "xxx",
+	})
+	if err == nil {
+		t.Error("expected env collision error")
+	}
+}
+
+func TestTestSettingsConfigPersistencePreservesPasswordHash(t *testing.T) {
+	store := newTestStore(t)
+	defer store.Close()
+
+	enabled := true
+	if _, err := store.UpdateTestSettingsConfig(UpdateTestSettingsRequest{
+		TestModeEnabled: &enabled,
+		TestPassword:    "persist-me-123",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	state := store.snapshotLocked()
+	raw, err := json.Marshal(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var reloadedState persistedState
+	if err := json.Unmarshal(raw, &reloadedState); err != nil {
+		t.Fatal(err)
+	}
+
+	reloaded := newTestStore(t)
+	defer reloaded.Close()
+	reloaded.applyState(reloadedState)
+	if !reloaded.GetTestSettingsConfig().TestModeEnabled {
+		t.Fatal("expected test mode to stay enabled after persistence reload")
+	}
+	if !reloaded.VerifyTestPassword("persist-me-123") {
+		t.Fatal("expected public test password to survive persistence reload")
+	}
+}
+
+func TestTestSettingsConfigResponseDoesNotExposePasswordHash(t *testing.T) {
+	response := testSettingsConfigResponse(TestSettingsConfig{
+		TestModeEnabled:  true,
+		TestPasswordHash: "salt:hash",
+	})
+	raw, err := json.Marshal(response)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) == "" || !json.Valid(raw) {
+		t.Fatalf("invalid response JSON: %s", raw)
+	}
+	if strings.Contains(string(raw), "salt:hash") || strings.Contains(string(raw), "test_password_hash") {
+		t.Fatalf("response leaked password hash: %s", raw)
+	}
+}
+
+func TestTestSettingsRateLimitKeyNormalizesRemotePort(t *testing.T) {
+	reqA := httptest.NewRequest("POST", "/api/public/test-settings/auth", nil)
+	reqA.RemoteAddr = "203.0.113.10:51000"
+	reqB := httptest.NewRequest("POST", "/api/public/test-settings/auth", nil)
+	reqB.RemoteAddr = "203.0.113.10:51001"
+
+	if testSettingsRateLimitKey(reqA) != "203.0.113.10" || testSettingsRateLimitKey(reqB) != "203.0.113.10" {
+		t.Fatalf("rate limit key should ignore remote port: %q / %q", testSettingsRateLimitKey(reqA), testSettingsRateLimitKey(reqB))
+	}
+}
+
+func TestTestSettingsRateLimitKeyUsesTrustedProxyForwardedFor(t *testing.T) {
+	req := httptest.NewRequest("POST", "/api/public/test-settings/auth", nil)
+	req.RemoteAddr = "127.0.0.1:42000"
+	req.Header.Set("X-Forwarded-For", "198.51.100.7, 127.0.0.1")
+
+	if got := testSettingsRateLimitKey(req); got != "198.51.100.7" {
+		t.Fatalf("rate limit key = %q, want forwarded client IP", got)
+	}
 }

--- a/backend/internal/core/test_publish_settings_test.go
+++ b/backend/internal/core/test_publish_settings_test.go
@@ -67,11 +67,11 @@ func TestTestSettingsStore(t *testing.T) {
     enabled := true
     _, err := store.UpdateTestSettingsConfig(UpdateTestSettingsRequest{
         TestModeEnabled: &enabled,
-        TestPassword:    "test123",
+        TestPassword:    "test12345",
     })
     if err != nil { t.Fatal(err) }
     if !store.GetTestSettingsConfig().TestModeEnabled { t.Error("expected enabled") }
-    if !store.VerifyTestPassword("test123") { t.Error("password should match") }
+    if !store.VerifyTestPassword("test12345") { t.Error("password should match") }
     if store.VerifyTestPassword("wrong") { t.Error("wrong pw should fail") }
 
     entry, err := store.AddTestSettingsEntry(AddTestEntryRequest{

--- a/frontend/public/publish-settings.html
+++ b/frontend/public/publish-settings.html
@@ -195,7 +195,7 @@ createApp({
 
     async function loadEntries() {
       try {
-        const data = await api('/api/public/test-settings/entries', {
+        const data = await api('/api/public/test-settings/entries/list', {
           method: 'POST',
           body: JSON.stringify({ password: sessionPassword.value }),
         });

--- a/frontend/public/publish-settings.html
+++ b/frontend/public/publish-settings.html
@@ -109,11 +109,11 @@ code { font-family: 'SF Mono', 'Fira Code', monospace; background: #0f172a; padd
       <!-- Entries list -->
       <div class="card">
         <h2>📋 Current Entries <span style="font-size:0.85rem;color:#94a3b8;font-weight:400;">({{ entries.length }})</span></h2>
-        
+
         <div v-if="entries.length === 0" style="text-align:center;padding:2rem;color:#64748b;">
           No entries yet. Add your first integration key above.
         </div>
-        
+
         <table v-else>
           <thead>
             <tr><th>Key</th><th>Type</th><th>Name</th><th>Value</th><th>Status</th><th></th></tr>

--- a/frontend/public/publish-settings.html
+++ b/frontend/public/publish-settings.html
@@ -1,0 +1,245 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MergeOS Test Publish Settings</title>
+<script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
+<style>
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #0f172a; color: #e2e8f0; min-height: 100vh; }
+.header { background: #1e293b; padding: 1rem 2rem; display: flex; align-items: center; gap: 0.75rem; border-bottom: 1px solid #334155; }
+.header img { width: 32px; height: 32px; }
+.header h1 { font-size: 1.25rem; font-weight: 600; }
+.header small { color: #94a3b8; font-size: 0.8rem; }
+.container { max-width: 800px; margin: 2rem auto; padding: 0 1rem; }
+.card { background: #1e293b; border: 1px solid #334155; border-radius: 8px; padding: 1.5rem; margin-bottom: 1rem; }
+.card h2 { font-size: 1.1rem; margin-bottom: 0.5rem; display: flex; align-items: center; gap: 0.5rem; }
+.card p { color: #94a3b8; font-size: 0.9rem; margin-bottom: 1rem; }
+label { display: block; margin-bottom: 0.75rem; }
+label span { display: block; font-size: 0.8rem; color: #94a3b8; margin-bottom: 0.25rem; }
+input, select { width: 100%; padding: 0.5rem 0.75rem; background: #0f172a; border: 1px solid #475569; border-radius: 6px; color: #e2e8f0; font-size: 0.9rem; }
+input:focus, select:focus { outline: none; border-color: #6366f1; }
+.btn { padding: 0.5rem 1rem; border: none; border-radius: 6px; cursor: pointer; font-size: 0.9rem; font-weight: 500; }
+.btn-primary { background: #6366f1; color: white; }
+.btn-primary:hover { background: #4f46e5; }
+.btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
+.btn-danger { background: #dc2626; color: white; }
+.btn-danger:hover { background: #b91c1c; }
+.btn-outline { background: transparent; border: 1px solid #475569; color: #e2e8f0; }
+.btn-outline:hover { background: #334155; }
+table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
+th { text-align: left; padding: 0.5rem; color: #94a3b8; font-weight: 500; border-bottom: 1px solid #334155; }
+td { padding: 0.5rem; border-bottom: 1px solid #1e293b; }
+.status-pill { display: inline-block; padding: 0.15rem 0.5rem; border-radius: 4px; font-size: 0.75rem; font-weight: 500; }
+.status-pill.green { background: #166534; color: #86efac; }
+.status-pill.amber { background: #92400e; color: #fde68a; }
+.status-pill.blue { background: #1e40af; color: #93c5fd; }
+code { font-family: 'SF Mono', 'Fira Code', monospace; background: #0f172a; padding: 0.15rem 0.4rem; border-radius: 4px; font-size: 0.8rem; color: #c084fc; }
+.error { color: #fca5a5; background: #7f1d1d; padding: 0.5rem; border-radius: 6px; margin-bottom: 0.5rem; font-size: 0.85rem; }
+.success { color: #86efac; background: #166534; padding: 0.5rem; border-radius: 6px; margin-bottom: 0.5rem; font-size: 0.85rem; }
+.form-row { display: grid; grid-template-columns: 1fr 1fr; gap: 0.75rem; }
+@media (max-width: 640px) { .form-row { grid-template-columns: 1fr; } }
+</style>
+</head>
+<body>
+<div id="app">
+  <div class="header">
+    <img src="/favicon.svg" alt="M" />
+    <div>
+      <h1>MergeOS</h1>
+      <small>Test Publish Settings</small>
+    </div>
+  </div>
+
+  <div class="container">
+    <!-- Login / Password gate -->
+    <div v-if="!authenticated" class="card">
+      <h2>🔑 Public Test Settings</h2>
+      <p>Enter the public test password to configure integration keys for testing.</p>
+      <div v-if="!testModeEnabled" class="error">Test mode is currently disabled. Ask an admin to enable it.</div>
+      <template v-if="testModeEnabled">
+        <label><span>Password</span>
+          <input v-model="passwordInput" @keyup.enter="login" placeholder="Enter public test password" type="password" />
+        </label>
+        <button class="btn btn-primary" :disabled="authBusy" @click="login">{{ authBusy ? 'Verifying...' : 'Access Publish Settings' }}</button>
+        <p v-if="authError" class="error">{{ authError }}</p>
+      </template>
+    </div>
+
+    <!-- Main Publish Settings UI -->
+    <template v-if="authenticated">
+      <div class="card">
+        <h2>⚙️ Integration Keys</h2>
+        <p>Add temporary test credentials for LLM providers, PayPal Sandbox, and USDT receivers.</p>
+      </div>
+
+      <!-- Add entry form -->
+      <div class="card">
+        <h2>➕ Add Entry</h2>
+        <form @submit.prevent="addEntry">
+          <div class="form-row">
+            <label><span>Integration Type</span>
+              <select v-model="form.integration_type">
+                <option value="llm">LLM</option>
+                <option value="paypal">PayPal Sandbox</option>
+                <option value="usdt">USDT</option>
+              </select>
+            </label>
+            <label><span>Display Name</span>
+              <input v-model="form.display_name" placeholder="OpenAI Test" />
+            </label>
+          </div>
+          <div class="form-row">
+            <label><span>Setting Key</span>
+              <input v-model="form.setting_key" placeholder="llm_test_openai_key" />
+            </label>
+            <label><span>Setting Value</span>
+              <input v-model="form.setting_value" placeholder="sk-..." type="password" />
+            </label>
+          </div>
+          <label><span>Extra Metadata (JSON)</span>
+            <input v-model="form.key_value_json" placeholder='{"env":"sandbox","model":"gpt-4"}' />
+          </label>
+          <button class="btn btn-primary" type="submit">Add Entry</button>
+        </form>
+        <p v-if="entryError" class="error">{{ entryError }}</p>
+      </div>
+
+      <!-- Entries list -->
+      <div class="card">
+        <h2>📋 Current Entries <span style="font-size:0.85rem;color:#94a3b8;font-weight:400;">({{ entries.length }})</span></h2>
+        
+        <div v-if="entries.length === 0" style="text-align:center;padding:2rem;color:#64748b;">
+          No entries yet. Add your first integration key above.
+        </div>
+        
+        <table v-else>
+          <thead>
+            <tr><th>Key</th><th>Type</th><th>Name</th><th>Value</th><th>Status</th><th></th></tr>
+          </thead>
+          <tbody>
+            <tr v-for="entry in entries" :key="entry.id">
+              <td><strong>{{ entry.setting_key }}</strong></td>
+              <td><span class="status-pill blue">{{ entry.integration_type }}</span></td>
+              <td>{{ entry.display_name || '-' }}</td>
+              <td><code>{{ entry.setting_value_hint }}</code></td>
+              <td><span :class="['status-pill', entry.status === 'active' ? 'green' : 'amber']">{{ entry.status }}</span></td>
+              <td><button class="btn btn-danger" style="padding:0.25rem 0.5rem;font-size:0.8rem;" @click="deleteEntry(entry.id)">Delete</button></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </template>
+  </div>
+</div>
+
+<script>
+const { createApp, ref, reactive, onMounted } = Vue;
+
+createApp({
+  setup() {
+    const authenticated = ref(false);
+    const testModeEnabled = ref(false);
+    const passwordInput = ref('');
+    const authBusy = ref(false);
+    const authError = ref('');
+    const entries = ref([]);
+    const entryError = ref('');
+    const sessionPassword = ref('');
+    const form = reactive({
+      integration_type: 'llm',
+      display_name: '',
+      setting_key: '',
+      setting_value: '',
+      key_value_json: '{}',
+    });
+
+    const API_BASE = window.location.origin;
+
+    async function api(path, opts = {}) {
+      const resp = await fetch(API_BASE + path, {
+        ...opts,
+        headers: { 'Content-Type': 'application/json', ...(opts.headers || {}) },
+      });
+      const text = await resp.text();
+      let payload = {};
+      try { payload = text ? JSON.parse(text) : {}; } catch { payload = { error: text || 'Request failed' }; }
+      if (!resp.ok) throw new Error(payload.error || 'Request failed');
+      return payload;
+    }
+
+    async function checkStatus() {
+      try {
+        const status = await api('/api/public/test-settings/status');
+        testModeEnabled.value = status.test_mode_enabled;
+      } catch {}
+    }
+
+    async function login() {
+      authBusy.value = true; authError.value = '';
+      try {
+        const result = await api('/api/public/test-settings/auth', {
+          method: 'POST',
+          body: JSON.stringify({ password: passwordInput.value }),
+        });
+        if (result.authenticated) {
+          sessionPassword.value = passwordInput.value;
+          authenticated.value = true;
+          passwordInput.value = '';
+          await loadEntries();
+        }
+      } catch(e) { authError.value = e.message; }
+      finally { authBusy.value = false; }
+    }
+
+    async function loadEntries() {
+      try {
+        const data = await api('/api/public/test-settings/entries', {
+          method: 'POST',
+          body: JSON.stringify({ password: sessionPassword.value }),
+        });
+        entries.value = Array.isArray(data) ? data : [];
+      } catch {}
+    }
+
+    async function addEntry() {
+      entryError.value = '';
+      let km = {};
+      try { km = JSON.parse(form.key_value_json || '{}'); } catch { entryError.value = 'Invalid JSON metadata.'; return; }
+      try {
+        const entry = await api('/api/public/test-settings/entries', {
+          method: 'POST',
+          body: JSON.stringify({
+            password: sessionPassword.value,
+            integration_type: form.integration_type,
+            display_name: form.display_name,
+            setting_key: form.setting_key,
+            setting_value: form.setting_value,
+            key_value_map: km,
+          }),
+        });
+        entries.value.unshift(entry);
+        form.integration_type = 'llm'; form.display_name = ''; form.setting_key = ''; form.setting_value = ''; form.key_value_json = '{}';
+      } catch(e) { entryError.value = e.message; }
+    }
+
+    async function deleteEntry(id) {
+      if (!confirm('Delete this entry?')) return;
+      try {
+        await api('/api/public/test-settings/entries/' + encodeURIComponent(id), {
+          method: 'DELETE',
+          body: JSON.stringify({ password: sessionPassword.value }),
+        });
+        entries.value = entries.value.filter(e => e.id !== id);
+      } catch(e) { entryError.value = e.message; }
+    }
+
+    onMounted(checkStatus);
+
+    return { authenticated, testModeEnabled, passwordInput, authBusy, authError, entries, entryError, form, login, addEntry, deleteEntry };
+  }
+}).mount('#app');
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Build a Publish Settings feature for MergeOS test mode. Admins can enable a public test status and set a shared public password. When test status is enabled, contributors who know that password can open a Publish Settings page and configure test integration keys (LLM, PayPal Sandbox, USDT) stored in the database—without touching production .env files or GitHub secrets.

**Fixes #141**
**Claim:** https://github.com/mergeos-bounties/mergeos/issues/1#issuecomment-4579437007
**Wallet:** `0x0bf82c4608a98f6f16507d89ddaacaa8879ad771`

## Backend Changes

### New Migration
- test_settings_config table + test_settings_entries table with indexes

### New Go File (test_publish_settings.go)
- Models, Store CRUD, 12 server handlers, password hashing, ENV collision detection, value masking

### Modified Files
- store.go, server.go, postgres_persistence.go — full persistence layer

### Frontend
- admin App.vue — Test Settings nav + toggle + key CRUD
- public publish-settings.html — standalone password-gated page

### Tests
- value masking, ENV collision, config/entry CRUD

## CI: 5/5 ✅ (Secret Scan + Backend + Frontend + Admin + Scan)
## Merge Status: MERGEABLE | CLEAN