### PR TITLE
Fix exact project escrow ledger scoping

### DIFF
--- a/backend/internal/core/escrow.go
+++ b/backend/internal/core/escrow.go
@@ -133,8 +133,7 @@ func projectEscrowLedgerApplies(project *Project, taskIDs map[string]bool, entry
 	if projectID == "" {
 		return false
 	}
-	haystack := strings.Join([]string{entry.FromAccount, entry.ToAccount, entry.Reference}, "|")
-	return strings.Contains(haystack, projectID)
+	return ledgerEntryReferencesID(entry, projectID)
 }
 
 func projectEscrowTaskRow(task *Task, paidCents int64) ProjectEscrowTask {

--- a/backend/internal/core/store_test.go
+++ b/backend/internal/core/store_test.go
@@ -1968,6 +1968,34 @@ func TestProjectEscrowRouteReturnsReserveReleaseSummary(t *testing.T) {
 	}
 }
 
+func TestProjectEscrowLedgerAppliesUsesExactIDBoundaries(t *testing.T) {
+	project := &Project{ID: "prj_001"}
+	taskIDs := map[string]bool{"tsk_001": true}
+
+	if !projectEscrowLedgerApplies(project, taskIDs, LedgerEntry{
+		Type:        "project_reserve",
+		FromAccount: "client:prj_001",
+		ToAccount:   "reserve:project:prj_001",
+		Reference:   "repo:mergeos-bounties/mergeos",
+	}) {
+		t.Fatal("expected escrow ledger matcher to include exact project reserve rows")
+	}
+	if projectEscrowLedgerApplies(project, taskIDs, LedgerEntry{
+		Type:        "project_reserve",
+		FromAccount: "client:prj_0010",
+		ToAccount:   "reserve:project:prj_0010",
+		Reference:   "repo:mergeos-bounties/mergeos",
+	}) {
+		t.Fatal("project escrow matched a sibling project with a shared ID prefix")
+	}
+	if projectEscrowLedgerApplies(project, taskIDs, LedgerEntry{
+		Type:      "task_payment",
+		Reference: "task:tsk_0010;pr:https://github.com/mergeos-bounties/mergeos/pull/10",
+	}) {
+		t.Fatal("project escrow matched a sibling task with a shared ID prefix")
+	}
+}
+
 func TestProjectPayoutsRouteReturnsSettlementContractAndSanitizesData(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := Config{


### PR DESCRIPTION
## Claim

- Claim Token comment: https://github.com/mergeos-bounties/mergeos/issues/1#issuecomment-4627594289
- Bounty amount: 25 MRG requested for a small backend bug fix; final amount is maintainer decision.
- Bounty type: bug bounty
- Bounty size: small

## Description

Project escrow summaries could treat sibling ledger references such as `prj_0010` or `tsk_0010` as if they belonged to `prj_001` when reserve rows were matched by loose prefixes.

This PR reuses the existing exact ledger ID boundary matcher for project escrow reserve rows, so only exact project/task references are included in the summary.

## Evidence

Before:
- Project escrow summary scope could include sibling project/task rows whose IDs shared the same prefix.

After:
- `prj_001` reserve/release summaries are constrained to exact ID boundaries and exclude sibling `prj_0010` / `tsk_0010` rows.

Additional logs or test output:
- `go test ./internal/core -run 'TestProjectEscrowLedgerAppliesUsesExactIDBoundaries|TestProjectEscrowRouteReturnsReserveReleaseSummary'` -> `ok mergeos/backend/internal/core 0.670s`
- Current GitHub Backend build is blocked by the shared Go 1.25.10 `govulncheck` baseline; #218 updates the backend Go patch version and is green. Secret scan, web checks, and MergeIDE are passing on this PR.

## Safety

- Reporting/scoping only.
- Does not change payout amounts, payout rules, manual credits, production wallets, or secrets.

## Tests

- [x] I ran the relevant tests.
- [x] I included the command output or explained why tests were not run.

## Bounty Checklist

- [x] I starred this repository before claiming or starting bounty work.
- [x] This PR links to a confirmed Claim Token comment.
- [x] This PR includes image evidence for UI bugs or logs/test output for non-UI bugs.
- [x] This PR explains the behavior before and after the fix.
- [x] This PR does not expose secrets, private keys, customer data, or sensitive production details.
