### PR TITLE
Tighten OAuth loopback redirect scheme detection

### DIFF
--- a/backend/internal/core/config_test.go
+++ b/backend/internal/core/config_test.go
@@ -219,6 +219,21 @@ func TestLocalOAuthRedirectBaseUsesForwardedFrontendHost(t *testing.T) {
 	}
 }
 
+func TestOAuthRedirectBaseOnlyDowngradesExactLoopbackHosts(t *testing.T) {
+	server := NewServer(Config{PrimaryDomain: "mergeos.shop"}, nil, nil)
+
+	spoofed := httptest.NewRequest("GET", "https://evil-localhost.example/api/auth/google/callback", nil)
+	spoofed.Host = "evil-localhost.example"
+	if got, want := server.getFrontRedirectBase(spoofed), "https://mergeos.shop"; got != want {
+		t.Fatalf("spoofed redirect base = %q, want %q", got, want)
+	}
+
+	loopback := httptest.NewRequest("GET", "http://127.0.0.1:18080/api/auth/google/callback", nil)
+	if got, want := server.getFrontRedirectBase(loopback), "http://mergeos.shop"; got != want {
+		t.Fatalf("loopback redirect base = %q, want %q", got, want)
+	}
+}
+
 func withTempConfigDir(t *testing.T) {
 	t.Helper()
 	previousDir, err := os.Getwd()

--- a/backend/internal/core/oauth.go
+++ b/backend/internal/core/oauth.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -301,10 +302,22 @@ func (s *Server) getFrontRedirectBase(r *http.Request) string {
 		return "http://127.0.0.1:5173"
 	}
 	scheme := "https"
-	if strings.Contains(r.Host, "localhost") || strings.Contains(r.Host, "127.0.0.1") {
+	if isLoopbackRedirectHost(r.Host) {
 		scheme = "http"
 	}
 	return scheme + "://" + s.cfg.PrimaryDomain
+}
+
+func isLoopbackRedirectHost(host string) bool {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return false
+	}
+	if parsedHost, _, err := net.SplitHostPort(host); err == nil {
+		host = parsedHost
+	}
+	host = strings.Trim(host, "[]")
+	return host == "localhost" || host == "127.0.0.1" || host == "::1"
 }
 
 func firstForwardedHeader(value string) string {


### PR DESCRIPTION
## Claim

- Claim Token comment: https://github.com/mergeos-bounties/mergeos/issues/1#issuecomment-4627602434
- Bounty amount: 25 MRG requested for a small backend security/redirect bug fix; final amount is maintainer decision.
- Bounty type: bug bounty
- Bounty size: small

## Description

OAuth callback redirect construction could downgrade to local `http` based on a host string that merely contained loopback text.

This PR parses the callback request host and only allows the local `http` redirect scheme for exact loopback hosts: `localhost`, `127.0.0.1`, and `::1`.

## Evidence

Before:
- Spoofed non-loopback host values containing `localhost` could be treated like local development callback hosts.

After:
- Only exact loopback hosts trigger the development `http` redirect behavior; non-loopback hosts keep the safer non-local handling.

Additional logs or test output:
- `go test ./internal/core -run 'TestOAuthRedirectBaseOnlyDowngradesExactLoopbackHosts|TestLocalOAuthRedirectBaseUsesForwardedFrontendHost'` -> `ok mergeos/backend/internal/core 0.397s`
- Current GitHub Backend build is blocked by the shared Go 1.25.10 `govulncheck` baseline; #218 updates the backend Go patch version and is green. Secret scan, web checks, and MergeIDE are passing on this PR.

## Safety

- Does not change OAuth provider credentials, callback paths, cookies, sessions, payout logic, or secrets.
- Preserves local loopback behavior for development callbacks.

## Tests

- [x] I ran the relevant tests.
- [x] I included the command output or explained why tests were not run.

## Bounty Checklist

- [x] I starred this repository before claiming or starting bounty work.
- [x] This PR links to a confirmed Claim Token comment.
- [x] This PR includes image evidence for UI bugs or logs/test output for non-UI bugs.
- [x] This PR explains the behavior before and after the fix.
- [x] This PR does not expose secrets, private keys, customer data, or sensitive production details.
