### PR TITLE
Sanitize SDK public limit queries

### DIFF
--- a/sdk/src/index.js
+++ b/sdk/src/index.js
@@ -107,7 +107,7 @@ export class MergeOSClient {
   }
 
   publicLiveFeed(options = {}) {
-    const limit = Number(options.limit) > 0 ? `?limit=${encodeURIComponent(Number(options.limit))}` : '';
+    const limit = publicLimitQuery(options.limit);
     return this.request(`/api/public/live-feed${limit}`, { auth: false });
   }
 
@@ -121,7 +121,7 @@ export class MergeOSClient {
   }
 
   publicProtocolAgents(options = {}) {
-    const limit = Number(options.limit) > 0 ? `?limit=${encodeURIComponent(Number(options.limit))}` : '';
+    const limit = publicLimitQuery(options.limit);
     return this.request(`/api/public/protocol/agents${limit}`, { auth: false });
   }
 
@@ -130,7 +130,7 @@ export class MergeOSClient {
   }
 
   publicProtocolEvents(options = {}) {
-    const limit = Number(options.limit) > 0 ? `?limit=${encodeURIComponent(Number(options.limit))}` : '';
+    const limit = publicLimitQuery(options.limit);
     return this.request(`/api/public/protocol/events${limit}`, { auth: false });
   }
 
@@ -455,6 +455,12 @@ export class MergeOSClient {
 
 export function createMergeOSClient(options = {}) {
   return new MergeOSClient(options);
+}
+
+function publicLimitQuery(limit) {
+  const value = Number(limit);
+  if (!Number.isFinite(value) || value <= 0) return '';
+  return `?limit=${encodeURIComponent(Math.floor(value))}`;
 }
 
 export function contractReferenceFromLedger(entry, options = {}) {

--- a/sdk/src/index.js
+++ b/sdk/src/index.js
@@ -116,7 +116,7 @@ export class MergeOSClient {
   }
 
   publicProtocolTasks(options = {}) {
-    const limit = Number(options.limit) > 0 ? `?limit=${encodeURIComponent(Number(options.limit))}` : '';
+    const limit = publicLimitQuery(options.limit);
     return this.request(`/api/public/protocol/tasks${limit}`, { auth: false });
   }
 

--- a/sdk/test/client.test.js
+++ b/sdk/test/client.test.js
@@ -582,14 +582,20 @@ test('sanitizes simple public limit query values', async () => {
     { status: 200, body: { items: [] } },
     { status: 200, body: { agents: [] } },
     { status: 200, body: { events: [] } },
+    { status: 200, body: { tasks: [] } },
+    { status: 200, body: { tasks: [] } },
   ]);
   const client = new MergeOSClient({ baseURL: 'https://mergeos.shop/', fetchImpl });
 
   await client.publicLiveFeed({ limit: Infinity });
   await client.publicProtocolAgents({ limit: 0 });
   await client.publicProtocolEvents({ limit: '2.9' });
+  await client.publicProtocolTasks({ limit: Infinity });
+  await client.publicProtocolTasks({ limit: '2.9' });
 
   assert.equal(fetchImpl.calls[0].url, 'https://mergeos.shop/api/public/live-feed');
   assert.equal(fetchImpl.calls[1].url, 'https://mergeos.shop/api/public/protocol/agents');
   assert.equal(fetchImpl.calls[2].url, 'https://mergeos.shop/api/public/protocol/events?limit=2');
+  assert.equal(fetchImpl.calls[3].url, 'https://mergeos.shop/api/public/protocol/tasks');
+  assert.equal(fetchImpl.calls[4].url, 'https://mergeos.shop/api/public/protocol/tasks?limit=2');
 });

--- a/sdk/test/client.test.js
+++ b/sdk/test/client.test.js
@@ -576,3 +576,20 @@ test('builds websocket URLs for event streams', () => {
   assert.equal(client.webSocketURL('/api/ws'), 'wss://mergeos.shop/api/ws');
   assert.equal(client.webSocketURL('ws://localhost:8080/api/ws'), 'ws://localhost:8080/api/ws');
 });
+
+test('sanitizes simple public limit query values', async () => {
+  const fetchImpl = fakeFetch([
+    { status: 200, body: { items: [] } },
+    { status: 200, body: { agents: [] } },
+    { status: 200, body: { events: [] } },
+  ]);
+  const client = new MergeOSClient({ baseURL: 'https://mergeos.shop/', fetchImpl });
+
+  await client.publicLiveFeed({ limit: Infinity });
+  await client.publicProtocolAgents({ limit: 0 });
+  await client.publicProtocolEvents({ limit: '2.9' });
+
+  assert.equal(fetchImpl.calls[0].url, 'https://mergeos.shop/api/public/live-feed');
+  assert.equal(fetchImpl.calls[1].url, 'https://mergeos.shop/api/public/protocol/agents');
+  assert.equal(fetchImpl.calls[2].url, 'https://mergeos.shop/api/public/protocol/events?limit=2');
+});


### PR DESCRIPTION
## Summary
- Add a shared SDK helper for public feed/protocol limit query strings.
- Omit non-finite and non-positive limits instead of sending malformed values such as Infinity.
- Floor decimal limits before sending them to integer-only Go handlers.
- Apply the same sanitizer to live feed, protocol tasks, protocol agents, and protocol events.

## Safety
- SDK URL construction only.
- Does not change backend feed limits, payout logic, wallets, production credentials, or admin behavior.

## Bounty claim
- Bounty issue/context: https://github.com/mergeos-bounties/mergeos/issues/1
- Exact claim comment: https://github.com/mergeos-bounties/mergeos/issues/1#issuecomment-4627609149
- Bounty type: bug bounty
- Claimed size/reward: small bug fix / 25 MRG under the issue #1 reward scale, subject to maintainer acceptance
- Repository starred before claim: yes
- Wallet/token receiver: github:yyswhsccc

## Evidence
- Before: `publicProtocolTasks({ limit: Infinity })` emitted `/api/public/protocol/tasks?limit=Infinity`; `publicProtocolTasks({ limit: '2.9' })` emitted `/api/public/protocol/tasks?limit=2.9`.
- After: `publicProtocolTasks({ limit: Infinity })` emits `/api/public/protocol/tasks`; `publicProtocolTasks({ limit: '2.9' })` emits `/api/public/protocol/tasks?limit=2`.
- The SDK test now covers task limits alongside live feed, agents, and events.

## Tests
- `git diff --check origin/master...HEAD` -> passed
- `python3 /Users/ssr/.codex/bounty-radar/automation/scan_hidden_unicode.py --repo /Users/ssr/.codex/bounty-radar/bounty-pr-workspace/mergeos-inspect --changed-files-from-git origin/master...HEAD --json-out /Users/ssr/.codex/bounty-radar/bounty-pr-workspace/mergeos-inspect/.bounty-validation/hidden-unicode-after-fix.json` -> passed, 2 files scanned, no findings
- `npm test --if-present` from `sdk/` -> 16/16 tests passed
- Direct SDK repro for `publicProtocolTasks()` -> `Infinity` dropped, decimal limit floored to `2`