### PR TITLE
Normalize scan GitHub worker accounts

### DIFF
--- a/scan/src/explorer.js
+++ b/scan/src/explorer.js
@@ -19,8 +19,15 @@ export function normalizeLedgerAccount(account = '') {
   const normalized = value.toLowerCase();
   if (/^wallet:0x[0-9a-f]{40}$/.test(normalized)) return normalized.slice('wallet:'.length);
   if (/^0x[0-9a-f]{40}$/.test(normalized)) return normalized;
+  if (normalized.startsWith('worker:github:')) return githubAccount(value.slice('worker:github:'.length));
+  if (normalized.startsWith('github:')) return githubAccount(value.slice('github:'.length));
   if (normalized.startsWith('reserve:task:')) return 'reserve:task';
   return value;
+}
+
+function githubAccount(username = '') {
+  const normalized = String(username || '').trim().replace(/^\/+|\/+$/g, '').toLowerCase();
+  return normalized ? `github:${normalized}` : '';
 }
 
 export function sortLedgerEntries(entries = []) {

--- a/scan/src/explorer.test.js
+++ b/scan/src/explorer.test.js
@@ -76,6 +76,8 @@ test('finds transactions, blocks and addresses from one search box', () => {
 test('treats github aliases as short public addresses', () => {
   assert.equal(githubUsernameFromAccount('github:hummusonrails'), 'hummusonrails');
   assert.equal(githubUsernameFromAccount('worker:github:hummusonrails'), 'hummusonrails');
+  assert.equal(normalizeLedgerAccount('worker:github:HummusOnRails'), 'github:hummusonrails');
+  assert.equal(normalizeLedgerAccount('github:/HummusOnRails/'), 'github:hummusonrails');
   assert.equal(githubProfileURL('github:hummusonrails'), 'https://github.com/hummusonrails');
   assert.equal(accountRole('github:hummusonrails'), 'GitHub Contributor');
 });
@@ -104,6 +106,38 @@ test('filters entries by type, account and free text', () => {
   assert.equal(filterEntries(entries, { type: 'token_mint' }).length, 1);
   assert.equal(filterEntries(entries, { account: 'project:prj_0001' }).length, 2);
   assert.equal(filterEntries(entries, { query: 'paypal' }).length, 1);
+});
+
+test('keeps github worker aliases on one scan account', () => {
+  const workerEntries = [
+    {
+      sequence: 1,
+      type: 'manual_credit',
+      from_account: 'reserve:task',
+      to_account: 'worker:github:HummusOnRails',
+      amount_cents: 25,
+      previous_hash: '0'.repeat(64),
+      entry_hash: 'a'.repeat(64),
+      created_at: '2026-05-26T00:00:00Z',
+    },
+    {
+      sequence: 2,
+      type: 'task_payment',
+      from_account: 'reserve:task',
+      to_account: 'github:hummusonrails',
+      amount_cents: 50,
+      previous_hash: 'a'.repeat(64),
+      entry_hash: 'b'.repeat(64),
+      created_at: '2026-05-26T00:01:00Z',
+    },
+  ];
+
+  const accounts = aggregateAccounts(workerEntries);
+  const worker = accounts.find((row) => row.account === 'github:hummusonrails');
+
+  assert.equal(worker.received_cents, 75);
+  assert.equal(worker.tx_count, 2);
+  assert.equal(filterEntries(workerEntries, { account: 'github:hummusonrails' }).length, 2);
 });
 
 test('builds explorer-level stats from ledger and marketplace payloads', () => {


### PR DESCRIPTION
## Summary
- Canonicalize worker:github:<name> and github:<name> to one scan account.
- Prevent public scan address pages from splitting historical GitHub worker aliases across separate rows.
- Add coverage for normalization, aggregate totals, and account filtering.

## Safety
- Scan/explorer display logic only.
- Does not change backend ledger entries, payout amounts, wallet linking, production credentials, or admin credit behavior.

## Bounty claim
- Claim comment: https://github.com/mergeos-bounties/mergeos/issues/1#issuecomment-4627614537
- Wallet/token receiver: github:yyswhsccc

## Tests
- npm test --if-present