### PR TITLE
Sanitize attachment download filenames

### DIFF
--- a/backend/internal/core/attachments.go
+++ b/backend/internal/core/attachments.go
@@ -118,6 +118,26 @@ func (s *Store) ListAttachments(userID string) []*Attachment {
 	return attachments
 }
 
+func safeAttachmentDownloadName(name string) string {
+	name = strings.TrimSpace(name)
+	var builder strings.Builder
+	for _, r := range name {
+		switch {
+		case r == '"' || r == '\\' || r == '/':
+			builder.WriteByte('_')
+		case r == '\r' || r == '\n' || r == '\t' || r < 0x20 || r == 0x7f:
+			builder.WriteByte('_')
+		default:
+			builder.WriteRune(r)
+		}
+	}
+	cleaned := strings.TrimSpace(builder.String())
+	if cleaned == "" {
+		return "attachment"
+	}
+	return cleaned
+}
+
 func detectContentType(path string) string {
 	file, err := os.Open(path)
 	if err != nil {

--- a/backend/internal/core/attachments_test.go
+++ b/backend/internal/core/attachments_test.go
@@ -1,0 +1,23 @@
+package core
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSafeAttachmentDownloadNameStripsHeaderUnsafeCharacters(t *testing.T) {
+	name := safeAttachmentDownloadName("report\"\r\nX-Bad: yes\\final/.pdf")
+
+	if strings.ContainsAny(name, "\"\r\n\\/\t") {
+		t.Fatalf("download filename still has header-unsafe characters: %q", name)
+	}
+	if !strings.Contains(name, "report") || !strings.Contains(name, "final") {
+		t.Fatalf("download filename lost expected readable parts: %q", name)
+	}
+}
+
+func TestSafeAttachmentDownloadNameUsesFallback(t *testing.T) {
+	if got := safeAttachmentDownloadName("\r\n\t"); got != "attachment" {
+		t.Fatalf("download filename fallback = %q, want attachment", got)
+	}
+}

--- a/backend/internal/core/server.go
+++ b/backend/internal/core/server.go
@@ -1088,7 +1088,7 @@ func (s *Server) downloadAttachment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", attachment.ContentType)
-	w.Header().Set("Content-Disposition", "inline; filename=\""+strings.ReplaceAll(attachment.OriginalName, "\"", "")+"\"")
+	w.Header().Set("Content-Disposition", "inline; filename=\""+safeAttachmentDownloadName(attachment.OriginalName)+"\"")
 	http.ServeFile(w, r, attachment.StoredPath)
 }
 


### PR DESCRIPTION
## Claim

- Claim Token comment: https://github.com/mergeos-bounties/mergeos/issues/1#issuecomment-4627623150
- Bounty amount: 25 MRG requested for a small backend/header bug fix; final amount is maintainer decision.
- Bounty type: bug bounty
- Bounty size: small

## Description

Attachment download filenames were written into `Content-Disposition` without enough header-safe cleanup for characters such as quotes, CR/LF, tabs, slashes, and backslashes.

This PR sanitizes download filenames before the header is written and falls back to a safe name when cleanup leaves an empty filename.

## Evidence

Before:
- Header-unsafe filename characters could be reflected into the attachment download `Content-Disposition` value.

After:
- Header-unsafe filename characters are replaced before the response header is written, and empty cleaned names use a safe fallback.

Additional logs or test output:
- `go test ./internal/core -run 'TestSafeAttachmentDownloadName'` -> `ok mergeos/backend/internal/core 0.392s`
- Current GitHub Backend build is blocked by the shared Go 1.25.10 `govulncheck` baseline; #218 updates the backend Go patch version and is green. Secret scan, web checks, and MergeIDE are passing on this PR.

## Safety

- Download header formatting only.
- Does not change upload storage paths, attachment authorization, payout logic, wallets, or secrets.

## Tests

- [x] I ran the relevant tests.
- [x] I included the command output or explained why tests were not run.

## Bounty Checklist

- [x] I starred this repository before claiming or starting bounty work.
- [x] This PR links to a confirmed Claim Token comment.
- [x] This PR includes image evidence for UI bugs or logs/test output for non-UI bugs.
- [x] This PR explains the behavior before and after the fix.
- [x] This PR does not expose secrets, private keys, customer data, or sensitive production details.
