### PR TITLE
Canonicalize manual credit GitHub worker aliases

### DIFF
--- a/backend/internal/core/admin_ledger.go
+++ b/backend/internal/core/admin_ledger.go
@@ -67,6 +67,9 @@ func normalizeAdminCreditWorkerID(value string) string {
 		return ""
 	}
 	lower := strings.ToLower(value)
+	if strings.HasPrefix(lower, "worker:github:") {
+		return githubWorkerAccount(strings.TrimPrefix(lower, "worker:"))
+	}
 	if strings.HasPrefix(lower, "github:") {
 		return githubWorkerAccount(value)
 	}

--- a/backend/internal/core/store_test.go
+++ b/backend/internal/core/store_test.go
@@ -3234,6 +3234,17 @@ func TestAdminCanCreateManualLedgerCredit(t *testing.T) {
 	}
 }
 
+func TestManualCreditWorkerGitHubAliasUsesCanonicalPayoutAccount(t *testing.T) {
+	store := &Store{wallets: map[string]*Wallet{}}
+
+	if got, want := normalizeAdminCreditWorkerID("worker:github:EliasX45"), "github:eliasx45"; got != want {
+		t.Fatalf("admin worker id = %q, want %q", got, want)
+	}
+	if got, want := store.payoutAccountForWorkerLocked("worker:github:EliasX45"), "github:eliasx45"; got != want {
+		t.Fatalf("payout account = %q, want %q", got, want)
+	}
+}
+
 func TestAdminOpsQueueReturnsDisputeModerationAndPayoutItems(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := Config{

--- a/backend/internal/core/wallets.go
+++ b/backend/internal/core/wallets.go
@@ -361,6 +361,13 @@ func (s *Store) payoutAccountForWorkerLocked(workerID string) string {
 			return walletAccount(address)
 		}
 	}
+	if username, ok := strings.CutPrefix(strings.ToLower(workerID), "worker:github:"); ok {
+		username = normalizeGitHubUsername(username)
+		if wallet := s.walletByGitHubLocked(username); wallet != nil {
+			return walletAccount(wallet.Address)
+		}
+		return githubWorkerAccount(username)
+	}
 	if username, ok := strings.CutPrefix(strings.ToLower(workerID), "github:"); ok {
 		username = normalizeGitHubUsername(username)
 		if wallet := s.walletByGitHubLocked(username); wallet != nil {


### PR DESCRIPTION
## Claim

- Claim Token comment: https://github.com/mergeos-bounties/mergeos/issues/1#issuecomment-4627632730
- Bounty amount: 25 MRG requested for a small backend alias-resolution bug fix; final amount is maintainer decision.
- Bounty type: bug bounty
- Bounty size: small
- Fix claim source: issue #1 claim token above. Separate QA verification reports may reference issue #64 for verifier compensation; that is not this fix PR's claim source.

## Description

Manual credit and payout-account resolution could treat `worker:github:<name>` as a distinct account instead of the canonical `github:<name>` payout alias.

This PR canonicalizes the worker GitHub alias before manual-credit storage and lower-level payout account resolution, preventing double-prefixed account identities.

## Evidence

Before:
- `worker:github:<name>` could create or reference a separate/double-prefixed account path instead of the canonical `github:<name>` alias.

After:
- `worker:github:<name>` resolves to `github:<name>` for manual credit input and payout account resolution without changing reward amounts or crediting any wallet.

Additional logs or test output:
- `go test ./internal/core -run 'TestManualCreditWorkerGitHubAliasUsesCanonicalPayoutAccount|TestAdminCanCreateManualLedgerCredit'` -> `ok mergeos/backend/internal/core 0.448s`
- Current GitHub Backend build is blocked by the shared Go 1.25.10 `govulncheck` baseline; #218 updates the backend Go patch version and is green. Secret scan, web checks, and MergeIDE are passing on this PR.

## Safety

- Alias canonicalization only.
- Does not change reward amounts, confirmation rules, production wallets, or admin secrets.
- Does not manually credit any wallet.

## Tests

- [x] I ran the relevant tests.
- [x] I included the command output or explained why tests were not run.

## Bounty Checklist

- [x] I starred this repository before claiming or starting bounty work.
- [x] This PR links to a confirmed Claim Token comment.
- [x] This PR includes image evidence for UI bugs or logs/test output for non-UI bugs.
- [x] This PR explains the behavior before and after the fix.
- [x] This PR does not expose secrets, private keys, customer data, or sensitive production details.
