### PR TITLE
Case-fold admin sensitive path checks

### DIFF
--- a/backend/internal/core/admin_github.go
+++ b/backend/internal/core/admin_github.go
@@ -535,7 +535,7 @@ func adminPullRequestSecretPath(path, name string) bool {
 }
 
 func adminPullRequestSecuritySensitivePath(path, name string) bool {
-	value := strings.Join([]string{path, name}, " ")
+	value := strings.ToLower(strings.Join([]string{path, name}, " "))
 	for _, keyword := range []string{
 		"admin", "auth", "oauth", "session", "token", "permission", "rbac",
 		"payment", "paypal", "usdt", "crypto", "webhook", "ledger", "escrow", "payout",

--- a/backend/internal/core/admin_github_test.go
+++ b/backend/internal/core/admin_github_test.go
@@ -209,6 +209,15 @@ func TestAdminPullRequestReadinessBlocksSecretFilesAndWarnsSensitiveCode(t *test
 	}
 }
 
+func TestAdminPullRequestSecuritySensitivePathIsCaseInsensitive(t *testing.T) {
+	if !adminPullRequestSecuritySensitivePath("Backend/Internal/Auth/Login.go", "Login.go") {
+		t.Fatal("expected uppercase auth path to be treated as security-sensitive")
+	}
+	if adminPullRequestSecuritySensitivePath("docs/Guide.md", "Guide.md") {
+		t.Fatal("expected ordinary docs path to stay low-risk")
+	}
+}
+
 func TestAdminPullRequestReadinessBlocksBroadDeletionHeavyDiff(t *testing.T) {
 	readiness := adminPullRequestReadiness(
 		&Task{Title: "Small frontend fix", Acceptance: "Keep changes scoped to the issue"},


### PR DESCRIPTION
## Claim

- Claim Token comment: https://github.com/mergeos-bounties/mergeos/issues/1#issuecomment-4627640940
- Bounty amount: 25 MRG requested for a small backend readiness-metadata bug fix; final amount is maintainer decision.
- Bounty type: bug bounty
- Bounty size: small
- Fix claim source: issue #1 claim token above. Separate QA verification reports may reference issue #64 for verifier compensation; that is not this fix PR's claim source.

## Description

Admin PR readiness checks could miss security-sensitive files when changed paths used uppercase or mixed-case segments such as `Backend/Internal/Auth/Login.go`.

This PR case-folds the readiness path/name haystack before matching sensitive keywords, so mixed-case paths still receive the expected admin readiness warning.

## Evidence

Before:
- Mixed-case sensitive paths could avoid the admin security-sensitive path signal.

After:
- Sensitive path detection is case-insensitive, while ordinary docs paths remain non-sensitive.

Additional logs or test output:
- `go test ./internal/core -run 'TestAdminPullRequestSecuritySensitivePathIsCaseInsensitive|TestAdminPullRequestReadinessBlocksSecretFilesAndWarnsSensitiveCode'` -> `ok mergeos/backend/internal/core 0.429s`
- Current GitHub Backend build is blocked by the shared Go 1.25.10 `govulncheck` baseline; #218 updates the backend Go patch version and is green. Secret scan, web checks, and MergeIDE are passing on this PR.

## Safety

- Admin readiness metadata only.
- Does not change merge behavior, payout amounts, wallets, production credentials, or manual credit logic.

## Tests

- [x] I ran the relevant tests.
- [x] I included the command output or explained why tests were not run.

## Bounty Checklist

- [x] I starred this repository before claiming or starting bounty work.
- [x] This PR links to a confirmed Claim Token comment.
- [x] This PR includes image evidence for UI bugs or logs/test output for non-UI bugs.
- [x] This PR explains the behavior before and after the fix.
- [x] This PR does not expose secrets, private keys, customer data, or sensitive production details.
