### PR TITLE
Sanitize SDK agent action numeric fields

### DIFF
--- a/sdk/src/index.js
+++ b/sdk/src/index.js
@@ -560,10 +560,22 @@ export function agentActionPayload(action, payload = {}) {
     agent_type: payload.agent_type || payload.agentType || defaultAgentTypeForAction(normalizedAction),
     status: payload.status || 'processed',
     reference_url: referenceURL,
-    duration_millis: Number(durationMillis) > 0 ? Number(durationMillis) : 0,
-    pull_number: Number(pullNumber) > 0 ? Number(pullNumber) : 0,
+    duration_millis: nonNegativeInteger(durationMillis),
+    pull_number: positiveInteger(pullNumber),
     labels: Array.isArray(payload.labels) ? payload.labels : [],
   };
+}
+
+function nonNegativeInteger(value) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return 0;
+  return Math.floor(parsed);
+}
+
+function positiveInteger(value) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return 0;
+  return Math.floor(parsed);
 }
 
 export function normalizeAgentAction(action = '') {

--- a/sdk/test/client.test.js
+++ b/sdk/test/client.test.js
@@ -181,6 +181,18 @@ test('builds and sends typed AI agent action helpers', async () => {
     pull_number: 12,
     labels: ['smoke'],
   });
+  assert.deepEqual(agentActionPayload('deploy', {
+    durationMillis: Infinity,
+    pullNumber: '12.9',
+  }), {
+    action: 'deploy',
+    agent_type: 'deployment-agent',
+    status: 'processed',
+    reference_url: '',
+    duration_millis: 0,
+    pull_number: 12,
+    labels: [],
+  });
 
   const fetchImpl = fakeFetch([
     { status: 201, body: { log: { action: 'review' } } },


### PR DESCRIPTION
## Summary
- Coerce SDK agent-action duration_millis and pull_number through finite integer helpers.
- Prevent Infinity from becoming null in serialized evidence payloads.
- Floor positive decimal pull numbers/durations before sending.

## Safety
- SDK payload construction only.
- Does not change backend agent-action storage, payout logic, wallets, production credentials, or admin behavior.

## Bounty claim
- Claim comment: https://github.com/mergeos-bounties/mergeos/issues/1#issuecomment-4627644194
- Wallet/token receiver: github:yyswhsccc

## Tests
- npm test --if-present