### PR TITLE
Sanitize SDK public limit queries (rebase of #212)

### DIFF
--- a/sdk/src/index.js
+++ b/sdk/src/index.js
@@ -127,7 +127,7 @@ export class MergeOSClient {
   }
 
   publicLedgerEvents(options = {}) {
-    const limit = Number(options.limit) > 0 ? `?limit=${encodeURIComponent(Number(options.limit))}` : '';
+    const limit = publicLimitQuery(options.limit);
     return this.request(`/api/public/ledger/events${limit}`, { auth: false });
   }
 
@@ -161,7 +161,7 @@ export class MergeOSClient {
 
   publicProtocolTasks(options = {}) {
     const query = queryString({
-      limit: Number(options.limit) > 0 ? Number(options.limit) : '',
+      limit: finitePositiveLimit(options.limit),
       task_id: options.task_id || options.taskID || '',
     });
     return this.request(`/api/public/protocol/tasks${query}`, { auth: false });
@@ -169,7 +169,7 @@ export class MergeOSClient {
 
   publicProtocolAgentQueue(options = {}) {
     const query = queryString({
-      limit: Number(options.limit) > 0 ? Number(options.limit) : '',
+      limit: finitePositiveLimit(options.limit),
     });
     return this.request(`/api/public/protocol/agent-queue${query}`, { auth: false });
   }
@@ -180,12 +180,12 @@ export class MergeOSClient {
   }
 
   publicProtocolAgents(options = {}) {
-    const limit = Number(options.limit) > 0 ? `?limit=${encodeURIComponent(Number(options.limit))}` : '';
+    const limit = publicLimitQuery(options.limit);
     return this.request(`/api/public/protocol/agents${limit}`, { auth: false });
   }
 
   publicProtocolContributors(options = {}) {
-    const limit = Number(options.limit) > 0 ? `?limit=${encodeURIComponent(Number(options.limit))}` : '';
+    const limit = publicLimitQuery(options.limit);
     return this.request(`/api/public/protocol/contributors${limit}`, { auth: false });
   }
 
@@ -1720,9 +1720,20 @@ function queryString(params = {}) {
   return value ? `?${value}` : '';
 }
 
+function finitePositiveLimit(limit) {
+  const value = Number(limit);
+  if (!Number.isFinite(value) || value <= 0) return '';
+  return Math.floor(value);
+}
+
+function publicLimitQuery(limit) {
+  const value = finitePositiveLimit(limit);
+  return value === '' ? '' : `?limit=${encodeURIComponent(value)}`;
+}
+
 function liveFeedQueryString(options = {}) {
   return queryString({
-    limit: Number(options.limit) > 0 ? Number(options.limit) : '',
+    limit: finitePositiveLimit(options.limit),
     after_id: options.after_id || options.afterID || options.cursor || '',
     since: normalizeSinceQueryValue(options.since),
   });

--- a/sdk/test/client.test.js
+++ b/sdk/test/client.test.js
@@ -916,6 +916,10 @@ test('builds and sends typed AI agent action helpers', async () => {
     duration_millis: 0,
     pull_number: 12,
     labels: [],
+    context_urls: [],
+    evidence: [],
+    runbook: [],
+    checks: [],
   });
 
   const fetchImpl = fakeFetch([
@@ -2243,4 +2247,27 @@ test('connects realtime streams from protocol discovery metadata', () => {
 
   assert.equal(sockets[0].url, 'wss://mergeos.shop/api/ws/protocol?scope=public&limit=24&after_id=event%3Alatest');
   assert.deepEqual(sockets[0].protocols, ['mergeos.event.v2']);
+});
+
+test('sanitizes public limit query values for non-finite inputs', async () => {
+  const fetchImpl = fakeFetch([
+    { status: 200, body: { items: [] } },
+    { status: 200, body: { agents: [] } },
+    { status: 200, body: { events: [] } },
+    { status: 200, body: { tasks: [] } },
+    { status: 200, body: { tasks: [] } },
+  ]);
+  const client = new MergeOSClient({ baseURL: 'https://mergeos.shop/', fetchImpl });
+
+  await client.publicLiveFeed({ limit: Infinity });
+  await client.publicProtocolAgents({ limit: 0 });
+  await client.publicProtocolEvents({ limit: '2.9' });
+  await client.publicProtocolTasks({ limit: Infinity });
+  await client.publicProtocolTasks({ limit: '2.9' });
+
+  assert.equal(fetchImpl.calls[0].url, 'https://mergeos.shop/api/public/live-feed');
+  assert.equal(fetchImpl.calls[1].url, 'https://mergeos.shop/api/public/protocol/agents');
+  assert.equal(fetchImpl.calls[2].url, 'https://mergeos.shop/api/public/protocol/events?limit=2');
+  assert.equal(fetchImpl.calls[3].url, 'https://mergeos.shop/api/public/protocol/tasks');
+  assert.equal(fetchImpl.calls[4].url, 'https://mergeos.shop/api/public/protocol/tasks?limit=2');
 });


### PR DESCRIPTION
## Summary
Maintainer rebase of #212 after conflicts with current master.

- Add `finitePositiveLimit` / `publicLimitQuery` helpers
- Apply to live feed, protocol tasks/agents/events/contributors, ledger events, and agent queue
- Add regression test for Infinity/0/decimal limits
- Adjust agent-action payload expectation for current SDK shape

Original work by @yyswhsccc in #212.

## Credit
25 MRG to github:yyswhsccc for the original fix.