### PR TITLE
feat: evidenceRequiredFromEvent + hasEvidenceRequirement SDK helpers

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -163,6 +163,29 @@ if (isLikelySolanaWallet(wallet)) {
 }
 ```
 
+## Evidence Requirement Helpers
+
+```js
+import { evidenceRequiredFromEvent, hasEvidenceRequirement } from '@mergeos/sdk';
+
+const event = {
+  evidence_required: ['security-review', 'test_output', 'security-review', ''],
+  type: 'task.submitted',
+};
+const requirements = evidenceRequiredFromEvent(event);
+// ['security_review', 'test_output']
+
+if (hasEvidenceRequirement(event, 'security-review')) {
+  console.log('Security review evidence is required for this task.');
+}
+
+// Works with live-feed items, arrays, and comma-separated strings too
+const feedItem = { evidenceRequired: 'scan_output,deployment_url' };
+console.log(evidenceRequiredFromEvent(feedItem)); // ['scan_output', 'deployment_url']
+```
+
+Keys are normalized: `security-review` → `security_review`, blanks and duplicates are ignored.
+
 ## Public APIs
 
 ```js

--- a/sdk/src/index.js
+++ b/sdk/src/index.js
@@ -1878,6 +1878,32 @@ function normalizeContextURLList(value = []) {
   return items.map((item) => String(item || '').trim()).filter(Boolean);
 }
 
+export function evidenceRequiredFromEvent(source) {
+  if (!source || typeof source !== 'object') return [];
+  const raw = source.evidence_required || source.evidenceRequired || source.evidence || [];
+  const items = Array.isArray(raw) ? raw : String(raw || '').split(',');
+  const seen = new Set();
+  return items.reduce((acc, item) => {
+    const key = normalizeEvidenceKey(item);
+    if (key && !seen.has(key)) {
+      seen.add(key);
+      acc.push(key);
+    }
+    return acc;
+  }, []);
+}
+
+export function hasEvidenceRequirement(source, requirement = '') {
+  if (!source || typeof source !== 'object') return false;
+  const required = evidenceRequiredFromEvent(source);
+  const normalized = normalizeEvidenceKey(requirement);
+  return required.includes(normalized);
+}
+
+function normalizeEvidenceKey(value = '') {
+  return String(value || '').trim().toLowerCase().replace(/-/g, '_').replace(/\s+/g, '_') || '';
+}
+
 function normalizeStringList(value = []) {
   const items = Array.isArray(value) ? value : String(value || '').split(',');
   return items.map((item) => String(item || '').trim()).filter(Boolean);

--- a/sdk/test/client.test.js
+++ b/sdk/test/client.test.js
@@ -28,6 +28,8 @@ import {
   agentSupportsAction,
   agentWorkPacketOutputContracts,
   aiWorkflowCurrentStage,
+  evidenceRequiredFromEvent,
+  hasEvidenceRequirement,
   aiWorkflowStage,
   aiWorkflowStageActionContract,
   aiWorkflowStageContextURLs,
@@ -2270,4 +2272,43 @@ test('sanitizes public limit query values for non-finite inputs', async () => {
   assert.equal(fetchImpl.calls[2].url, 'https://mergeos.shop/api/public/protocol/events?limit=2');
   assert.equal(fetchImpl.calls[3].url, 'https://mergeos.shop/api/public/protocol/tasks');
   assert.equal(fetchImpl.calls[4].url, 'https://mergeos.shop/api/public/protocol/tasks?limit=2');
+});
+
+test('evidenceRequiredFromEvent extracts and deduplicates requirements', () => {
+  const event = {
+    evidence_required: ['security-review', 'test_output', 'security-review', ''],
+    type: 'task.submitted',
+  };
+  const result = evidenceRequiredFromEvent(event);
+  assert.deepEqual(result, ['security_review', 'test_output']);
+});
+
+test('evidenceRequiredFromEvent handles camelCase evidenceRequired', () => {
+  const event = { evidenceRequired: 'scan_output,deployment_url' };
+  const result = evidenceRequiredFromEvent(event);
+  assert.deepEqual(result, ['scan_output', 'deployment_url']);
+});
+
+test('evidenceRequiredFromEvent handles direct evidence array', () => {
+  const result = evidenceRequiredFromEvent({ evidence: ['SECURITY-REVIEW', ' Test_Output '] });
+  assert.deepEqual(result, ['security_review', 'test_output']);
+});
+
+test('evidenceRequiredFromEvent returns empty array for empty input', () => {
+  assert.deepEqual(evidenceRequiredFromEvent({}), []);
+  assert.deepEqual(evidenceRequiredFromEvent(null), []);
+  assert.deepEqual(evidenceRequiredFromEvent(undefined), []);
+});
+
+test('hasEvidenceRequirement matches normalized requirements', () => {
+  const event = { evidence_required: ['security-review', 'test_output'] };
+  assert.equal(hasEvidenceRequirement(event, 'security-review'), true);
+  assert.equal(hasEvidenceRequirement(event, 'security_review'), true);
+  assert.equal(hasEvidenceRequirement(event, 'Security-Review'), true);
+  assert.equal(hasEvidenceRequirement(event, 'deployment_url'), false);
+});
+
+test('hasEvidenceRequirement returns false for empty source', () => {
+  assert.equal(hasEvidenceRequirement({}, 'anything'), false);
+  assert.equal(hasEvidenceRequirement(null, 'test'), false);
 });


### PR DESCRIPTION
Fixes #238

## Changes

- `evidenceRequiredFromEvent(source)` — extracts evidence requirements from protocol/live-feed events, normalizes kebab-case to snake_case, deduplicates, ignores blanks
- `hasEvidenceRequirement(source, requirement)` — checks if a specific requirement exists after normalization
- Both handle arrays, comma-separated strings, `evidence_required`, `evidenceRequired`, and `evidence` fields
- 6 unit tests covering dedup, normalization, camelCase, empty input, edge cases
- README snippet with usage examples

All 39 SDK tests pass (+6 new).