### PR TITLE
fix: SMTP notification persistence + graceful offline fallback

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -67,9 +67,11 @@ SSL_REVIEW_DOMAINS=mergeos.shop,uta.mergeos.shop,scan.mergeos.shop
 SSL_REVIEW_INTERVAL_MINUTES=360
 SSL_EXPIRY_WARN_DAYS=14
 
-# Customer email notifications.
-SMTP_HOST=
-SMTP_PORT=587
-SMTP_USERNAME=
-SMTP_PASSWORD=
-SMTP_FROM=noreply@mergeos.local
+# SMTP email notifications for password reset, project events, and alerts.
+# When SMTP is unset or unreachable, notifications persist in the store
+# with status "logged:mail-not-configured" and no user-facing error occurs.
+SMTP_HOST=                    # SMTP server hostname (e.g. smtp.sendgrid.net)
+SMTP_PORT=587                 # SMTP server port (587 for STARTTLS, 465 for SSL)
+SMTP_USERNAME=                # SMTP authentication username
+SMTP_PASSWORD=                # SMTP authentication password
+SMTP_FROM=noreply@mergeos.local  # From address for outgoing mail

--- a/backend/internal/core/email_test.go
+++ b/backend/internal/core/email_test.go
@@ -1,0 +1,78 @@
+package core
+
+import (
+	"testing"
+)
+
+func TestEmailSenderReturnsLoggedWhenSMTPNotConfigured(t *testing.T) {
+	cfg := Config{}
+	sender := NewEmailSender(cfg)
+	result := sender.Send("user@example.com", "Test Subject", "Test body")
+	if result != "logged:mail-not-configured" {
+		t.Errorf("expected logged:mail-not-configured, got %s", result)
+	}
+}
+
+func TestEmailSenderReturnsSkippedWhenNoRecipient(t *testing.T) {
+	cfg := Config{
+		SMTPHost:     "smtp.example.com",
+		SMTPPort:     "587",
+		SMTPUsername: "user",
+		SMTPPassword: "pass",
+		SMTPFrom:     "noreply@test.local",
+	}
+	sender := NewEmailSender(cfg)
+	result := sender.Send("", "Test Subject", "Test body")
+	if result != "skipped:no-recipient" {
+		t.Errorf("expected skipped:no-recipient, got %s", result)
+	}
+}
+
+func TestEmailSenderReturnsSkippedWhenWhitespaceRecipient(t *testing.T) {
+	cfg := Config{
+		SMTPHost:     "smtp.example.com",
+		SMTPPort:     "587",
+		SMTPUsername: "user",
+		SMTPPassword: "pass",
+		SMTPFrom:     "noreply@test.local",
+	}
+	sender := NewEmailSender(cfg)
+	result := sender.Send("  ", "Test Subject", "Test body")
+	if result != "skipped:no-recipient" {
+		t.Errorf("expected skipped:no-recipient, got %s", result)
+	}
+}
+
+func TestEmailSenderReturnsErrorOnBadHost(t *testing.T) {
+	cfg := Config{
+		SMTPHost:     "nonexistent.smtp.local",
+		SMTPPort:     "25",
+		SMTPUsername: "user",
+		SMTPPassword: "pass",
+		SMTPFrom:     "noreply@test.local",
+	}
+	sender := NewEmailSender(cfg)
+	result := sender.Send("user@example.com", "Test Subject", "Test body")
+	if len(result) < 6 || result[:6] != "error:" {
+		t.Errorf("expected error: prefix, got %s", result)
+	}
+}
+
+func TestEmailSenderSMTPReadyFalseWhenUnconfigured(t *testing.T) {
+	cfg := Config{}
+	if cfg.SMTPReady() {
+		t.Error("expected SMTPReady() to be false with empty config")
+	}
+}
+
+func TestEmailSenderSMTPReadyTrueWhenConfigured(t *testing.T) {
+	cfg := Config{
+		SMTPHost:     "smtp.example.com",
+		SMTPUsername: "user",
+		SMTPPassword: "pass",
+		SMTPFrom:     "noreply@test.local",
+	}
+	if !cfg.SMTPReady() {
+		t.Error("expected SMTPReady() to be true with valid config")
+	}
+}


### PR DESCRIPTION
Fixes #233

## Changes

Audited the existing notification + SMTP path:

- **No 500s**: `EmailSender.Send()` returns status string `"logged:mail-not-configured"` when SMTP is unset (never panics)
- **Persistence**: Notifications are stored via `addNotificationLocked()` with the send result as status — already persists regardless of SMTP state
- **Env docs**: Expanded `.env.example` SMTP section with field descriptions
- **Tests**: 6 new tests in `email_test.go` covering:
  - SMTP not configured → `logged:mail-not-configured`
  - No recipient → `skipped:no-recipient`
  - Whitespace recipient → `skipped:no-recipient`
  - Bad SMTP host → `error:*`
  - `SMTPReady()` false when unconfigured
  - `SMTPReady()` true when configured

All tests cover offline and failure paths without an external SMTP dependency.