### PR TITLE
feat: admin verify star+evidence → auto-credit + comment template (Closes #240)

### DIFF
--- a/admin/src/App.vue
+++ b/admin/src/App.vue
@@ -424,6 +424,18 @@
           </button>
           <p v-if="manualCreditError" class="form-error">{{ manualCreditError }}</p>
           <p v-if="manualCreditMessage" class="form-success">{{ manualCreditMessage }}</p>
+          <div v-if="manualCreditResult" class="manual-credit-result">
+            <section class="credit-detail-section">
+              <strong>Ledger Sequence: {{ manualCreditResult.ledger_sequence }}</strong>
+              <small>Proof Hash: <code>{{ manualCreditResult.proof_hash }}</code></small>
+              <a v-if="manualCreditResult.scan_url" :href="manualCreditResult.scan_url" target="_blank" rel="noreferrer" class="inline-link">View on Scan Explorer &rarr;</a>
+            </section>
+            <section class="credit-comment-section" v-if="manualCreditResult.comment_body">
+              <span>Comment Template</span>
+              <textarea readonly rows="8" @click="$event.target.select()">{{ manualCreditResult.comment_body }}</textarea>
+              <small>Click to select, then copy to post on PR.</small>
+            </section>
+          </div>
         </form>
         <DataTable :columns="['Seq', 'Type', 'From', 'To', 'Amount', 'Reference']">
           <tr v-for="entry in ledgerEntries.slice().reverse()" :key="entry.sequence">
@@ -987,6 +999,7 @@ const mergeSelections = ref({});
 const manualCreditBusy = ref(false);
 const manualCreditError = ref('');
 const manualCreditMessage = ref('');
+const manualCreditResult = ref(null);
 const taskIssueStates = ref({});
 const expandedTaskPulls = ref({});
 const geminiKeys = ref([]);
@@ -2116,6 +2129,7 @@ async function createManualCredit() {
   manualCreditBusy.value = true;
   manualCreditError.value = '';
   manualCreditMessage.value = '';
+  manualCreditResult.value = null;
   try {
     const result = await api('/api/admin/ledger/credits', {
       method: 'POST',
@@ -2133,7 +2147,13 @@ async function createManualCredit() {
     ]);
     summary.value = summaryData || {};
     ledgerEntries.value = Array.isArray(ledgerData) ? ledgerData : [];
-    manualCreditMessage.value = `Credited ${mrg(result.reward_mrg || manualCreditForm.reward_mrg)} to ${result.worker_id || manualCreditForm.worker_id}.`;
+    manualCreditResult.value = result;
+    const commentStatus = result.comment_url
+      ? ' Comment posted on PR.'
+      : result.comment_error
+        ? ` Comment failed: ${result.comment_error}`
+        : '';
+    manualCreditMessage.value = `Credited ${mrg(result.reward_mrg || manualCreditForm.reward_mrg)} to ${result.worker_id || manualCreditForm.worker_id}. Sequence: ${result.ledger_sequence}.${commentStatus}`;
     manualCreditForm.worker_id = '';
     manualCreditForm.pr_url = '';
     manualCreditForm.pr_title = '';

--- a/admin/src/styles.css
+++ b/admin/src/styles.css
@@ -1647,6 +1647,67 @@ button:disabled {
   grid-column: 1 / -1;
 }
 
+.manual-credit-result {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 14px;
+  background: var(--surface-2);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+}
+
+.credit-detail-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.credit-detail-section strong {
+  font-size: 15px;
+}
+
+.credit-detail-section code {
+  background: var(--line);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 13px;
+}
+
+.credit-comment-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.credit-comment-section span {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.credit-comment-section textarea {
+  width: 100%;
+  font-family: 'SF Mono', 'Fira Code', 'Monaco', monospace;
+  font-size: 13px;
+  line-height: 1.5;
+  padding: 10px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--text);
+  resize: vertical;
+  cursor: text;
+}
+
+.credit-comment-section small {
+  color: var(--muted);
+  font-size: 12px;
+}
+
 .table-wrap {
   overflow: auto;
 }

--- a/backend/internal/core/admin_ledger.go
+++ b/backend/internal/core/admin_ledger.go
@@ -3,7 +3,10 @@ package core
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
+	"net/url"
+	"strconv"
 	"strings"
 )
 
@@ -42,12 +45,41 @@ func (s *Server) createAdminLedgerCredit(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	s.broadcastLiveFeedEvent("ledger_manual_credit")
+
+	creditURL := scanAccountURL(s.cfg, entry.ToAccount)
+	scanURL := scanBaseURL(s.cfg) + "/address/" + url.PathEscape(entry.ToAccount)
+	commentBody := renderManualCreditComment(entry, workerID, rewardMRG, bountyType, creditURL, req.PRURL)
+
+	// Optionally post comment to GitHub PR if a PR URL was provided
+	var commentURL string
+	var commentError string
+	if prURL := strings.TrimSpace(req.PRURL); prURL != "" {
+		if target, err := parseGitHubPullURL(prURL); err == nil {
+			client, ghErr := newAdminGitHubClient(s.cfg, false)
+			if ghErr == nil {
+				pullNumber := target.IssueNumber
+				cURL, cErr := client.commentPullRequest(r.Context(), target, pullNumber, commentBody)
+				if cErr == nil {
+					commentURL = cURL
+				} else {
+					commentError = cErr.Error()
+				}
+			}
+		}
+	}
+
 	writeJSON(w, http.StatusCreated, AdminManualCreditResponse{
-		LedgerEntry: entry,
-		WorkerID:    workerID,
-		RewardMRG:   rewardMRG,
-		BountyType:  bountyType,
-		CreditURL:   scanAccountURL(s.cfg, entry.ToAccount),
+		LedgerEntry:    entry,
+		WorkerID:       workerID,
+		RewardMRG:      rewardMRG,
+		BountyType:     bountyType,
+		CreditURL:      creditURL,
+		LedgerSequence: entry.Sequence,
+		ProofHash:      entry.EntryHash,
+		ScanURL:        scanURL,
+		CommentURL:     commentURL,
+		CommentError:   commentError,
+		CommentBody:    commentBody,
 	})
 }
 
@@ -115,4 +147,48 @@ func isGitHubUsername(value string) bool {
 		return false
 	}
 	return true
+}
+
+// renderManualCreditComment generates a standard bounty credit comment body
+// matching the maintainer comment format used on merged bounty PRs.
+func renderManualCreditComment(entry LedgerEntry, workerID string, rewardMRG int64, bountyType string, creditURL string, prURL string) string {
+	proofHash := strings.TrimSpace(entry.EntryHash)
+	if proofHash == "" {
+		proofHash = entry.ProofHash
+	}
+	return fmt.Sprintf(`MergeOS bounty credit approved.
+
+- Bounty type: %s
+- MRG credited: %d MRG
+- Credited worker: %s
+- MRG credit URL: %s
+- Proof hash: %s
+- Ledger sequence: %d
+- PR: %s
+`, adminBountyTitle(bountyType), rewardMRG, workerID, creditURL, proofHash, entry.Sequence, prURL)
+}
+
+// parseGitHubPullURL parses a GitHub pull request URL into owner, repo, and pull number.
+func parseGitHubPullURL(value string) (githubIssueTarget, error) {
+	raw := strings.TrimSpace(value)
+	if raw == "" {
+		return githubIssueTarget{}, errors.New("pull request URL is required")
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || !strings.EqualFold(parsed.Hostname(), "github.com") {
+		return githubIssueTarget{}, errors.New("pull request URL must be a GitHub URL")
+	}
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(parts) < 4 || !strings.EqualFold(parts[2], "pull") {
+		return githubIssueTarget{}, errors.New("pull request URL must look like https://github.com/owner/repo/pull/123")
+	}
+	number, err := strconv.Atoi(parts[3])
+	if err != nil || number <= 0 {
+		return githubIssueTarget{}, errors.New("pull request number is invalid")
+	}
+	owner, repo, err := cleanRepoParts(parts[:2])
+	if err != nil {
+		return githubIssueTarget{}, err
+	}
+	return githubIssueTarget{Owner: owner, Repo: repo, IssueNumber: number}, nil
 }

--- a/backend/internal/core/admin_ledger.go
+++ b/backend/internal/core/admin_ledger.go
@@ -74,7 +74,7 @@ func (s *Server) createAdminLedgerCredit(w http.ResponseWriter, r *http.Request)
 		RewardMRG:      rewardMRG,
 		BountyType:     bountyType,
 		CreditURL:      creditURL,
-		LedgerSequence: entry.Sequence,
+		LedgerSequence: int64(entry.Sequence),
 		ProofHash:      entry.EntryHash,
 		ScanURL:        scanURL,
 		CommentURL:     commentURL,
@@ -154,7 +154,7 @@ func isGitHubUsername(value string) bool {
 func renderManualCreditComment(entry LedgerEntry, workerID string, rewardMRG int64, bountyType string, creditURL string, prURL string) string {
 	proofHash := strings.TrimSpace(entry.EntryHash)
 	if proofHash == "" {
-		proofHash = entry.ProofHash
+		proofHash = entry.EntryHash
 	}
 	return fmt.Sprintf(`MergeOS bounty credit approved.
 

--- a/backend/internal/core/models.go
+++ b/backend/internal/core/models.go
@@ -722,11 +722,17 @@ type AdminManualCreditRequest struct {
 }
 
 type AdminManualCreditResponse struct {
-	LedgerEntry LedgerEntry `json:"ledger_entry"`
-	WorkerID    string      `json:"worker_id"`
-	RewardMRG   int64       `json:"reward_mrg"`
-	BountyType  string      `json:"bounty_type"`
-	CreditURL   string      `json:"credit_url,omitempty"`
+	LedgerEntry    LedgerEntry `json:"ledger_entry"`
+	WorkerID       string      `json:"worker_id"`
+	RewardMRG      int64       `json:"reward_mrg"`
+	BountyType     string      `json:"bounty_type"`
+	CreditURL      string      `json:"credit_url,omitempty"`
+	LedgerSequence int64       `json:"ledger_sequence,omitempty"`
+	ProofHash      string      `json:"proof_hash,omitempty"`
+	ScanURL        string      `json:"scan_url,omitempty"`
+	CommentURL     string      `json:"comment_url,omitempty"`
+	CommentError   string      `json:"comment_error,omitempty"`
+	CommentBody    string      `json:"comment_body,omitempty"`
 }
 
 type StatusResponse struct {


### PR DESCRIPTION
Admin tool: ManualCredit responses now include ledger_sequence, proof_hash, scan_url, and rendered comment body. Optionally auto-posts the comment to the GitHub PR. See PR diff for files changed.