### PR TITLE
feat: Admin manual credit UX improvements (#240)

### DIFF
--- a/admin/src/App.vue
+++ b/admin/src/App.vue
@@ -424,6 +424,31 @@
           </button>
           <p v-if="manualCreditError" class="form-error">{{ manualCreditError }}</p>
           <p v-if="manualCreditMessage" class="form-success">{{ manualCreditMessage }}</p>
+          <article v-if="manualCreditResult" class="credit-result-card">
+            <div class="credit-result-head">
+              <span class="metric-icon green"><CheckCircle2 :size="18" /></span>
+              <strong>Credit result</strong>
+            </div>
+            <div class="credit-result-details">
+              <label>Worker</label>
+              <strong>{{ manualCreditResult.worker_id }}</strong>
+              <label>MRG</label>
+              <strong>{{ mrg(manualCreditResult.reward_mrg) }}</strong>
+              <label>Ledger sequence</label>
+              <strong><a :href="manualCreditResult.scan_url || manualCreditResult.credit_url" target="_blank" rel="noreferrer">#{{ manualCreditResult.ledger_sequence || manualCreditResult.ledger_entry?.sequence }}</a></strong>
+              <label>Proof hash</label>
+              <strong><code>{{ shortRef(manualCreditResult.proof_hash || manualCreditResult.ledger_entry?.entry_hash) }}</code></strong>
+              <label>Bounty type</label>
+              <strong>{{ titleize(manualCreditResult.bounty_type) }}</strong>
+            </div>
+            <div class="credit-result-comment" v-if="manualCreditResult.comment_template">
+              <label>Comment template</label>
+              <pre class="comment-pre">{{ manualCreditResult.comment_template }}</pre>
+              <button class="compact-action" type="button" @click="copyCreditComment(manualCreditResult.comment_template)">
+                {{ commentCopied ? 'Copied!' : 'Copy comment' }}
+              </button>
+            </div>
+          </article>
         </form>
         <DataTable :columns="['Seq', 'Type', 'From', 'To', 'Amount', 'Reference']">
           <tr v-for="entry in ledgerEntries.slice().reverse()" :key="entry.sequence">
@@ -987,6 +1012,8 @@ const mergeSelections = ref({});
 const manualCreditBusy = ref(false);
 const manualCreditError = ref('');
 const manualCreditMessage = ref('');
+const manualCreditResult = ref(null);
+const commentCopied = ref(false);
 const taskIssueStates = ref({});
 const expandedTaskPulls = ref({});
 const geminiKeys = ref([]);
@@ -2116,6 +2143,7 @@ async function createManualCredit() {
   manualCreditBusy.value = true;
   manualCreditError.value = '';
   manualCreditMessage.value = '';
+  manualCreditResult.value = null;
   try {
     const result = await api('/api/admin/ledger/credits', {
       method: 'POST',
@@ -2133,7 +2161,8 @@ async function createManualCredit() {
     ]);
     summary.value = summaryData || {};
     ledgerEntries.value = Array.isArray(ledgerData) ? ledgerData : [];
-    manualCreditMessage.value = `Credited ${mrg(result.reward_mrg || manualCreditForm.reward_mrg)} to ${result.worker_id || manualCreditForm.worker_id}.`;
+    manualCreditResult.value = result;
+    manualCreditMessage.value = `Credited ${mrg(result.reward_mrg || manualCreditForm.reward_mrg)} to ${result.worker_id || manualCreditForm.worker_id}. Ledger sequence #${result.ledger_sequence || result.ledger_entry?.sequence || '?'} recorded.`;
     manualCreditForm.worker_id = '';
     manualCreditForm.pr_url = '';
     manualCreditForm.pr_title = '';
@@ -2141,6 +2170,17 @@ async function createManualCredit() {
     manualCreditError.value = error.message;
   } finally {
     manualCreditBusy.value = false;
+  }
+}
+
+async function copyCreditComment(text) {
+  if (!hasWindow || !text) return;
+  try {
+    await navigator.clipboard.writeText(text);
+    commentCopied.value = true;
+    setTimeout(() => { commentCopied.value = false; }, 2000);
+  } catch {
+    commentCopied.value = false;
   }
 }
 

--- a/admin/src/styles.css
+++ b/admin/src/styles.css
@@ -1647,6 +1647,82 @@ button:disabled {
   grid-column: 1 / -1;
 }
 
+.credit-result-card {
+  grid-column: 1 / -1;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--surface-2);
+  padding: 14px 16px;
+  display: grid;
+  gap: 10px;
+}
+
+.credit-result-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.credit-result-details {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 6px 12px;
+  align-items: center;
+  font-size: 13px;
+}
+
+.credit-result-details label {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.credit-result-details strong a {
+  color: var(--blue);
+  text-decoration: none;
+}
+
+.credit-result-details strong a:hover {
+  text-decoration: underline;
+}
+
+.credit-result-details code {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  font-size: 12px;
+  background: var(--bg);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: 2px 6px;
+}
+
+.credit-result-comment {
+  display: grid;
+  gap: 6px;
+}
+
+.credit-result-comment label {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.comment-pre {
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  background: var(--bg);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 10px 12px;
+  margin: 0;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
 .table-wrap {
   overflow: auto;
 }

--- a/backend/internal/core/admin_github_test.go
+++ b/backend/internal/core/admin_github_test.go
@@ -114,6 +114,46 @@ func TestRenderMergeOSPullCommentLinksScanCreditAccount(t *testing.T) {
 	}
 }
 
+func TestRenderManualCreditCommentIncludesAllFields(t *testing.T) {
+	comment := renderManualCreditComment(
+		"github:testuser",
+		100,
+		"major-feature",
+		"https://scan.mergeos.shop/address/github:testuser",
+		42,
+		"abc123hash",
+		"https://github.com/org/repo/pull/99",
+	)
+	if !strings.Contains(comment, "Merge URL: https://github.com/org/repo/pull/99") {
+		t.Fatalf("comment missing merge URL: %s", comment)
+	}
+	if !strings.Contains(comment, "MRG credit URL: https://scan.mergeos.shop/address/github:testuser") {
+		t.Fatalf("comment missing credit URL: %s", comment)
+	}
+	if !strings.Contains(comment, "Credited worker: github:testuser") {
+		t.Fatalf("comment missing worker: %s", comment)
+	}
+	if !strings.Contains(comment, "MRG credited: 100 MRG") {
+		t.Fatalf("comment missing reward: %s", comment)
+	}
+	if !strings.Contains(comment, "Ledger sequence: 42") {
+		t.Fatalf("comment missing ledger sequence: %s", comment)
+	}
+	if !strings.Contains(comment, "Proof hash: abc123hash") {
+		t.Fatalf("comment missing proof hash: %s", comment)
+	}
+	if !strings.Contains(comment, "Bounty type: Major feature bounty") {
+		t.Fatalf("comment missing bounty type title: %s", comment)
+	}
+}
+
+func TestRenderManualCreditCommentFallbackPRURL(t *testing.T) {
+	comment := renderManualCreditComment("github:user", 25, "future-small", "https://scan.mergeos.shop", 10, "hash1", "")
+	if !strings.Contains(comment, "Merge URL: manual-credit") {
+		t.Fatalf("comment missing fallback merge URL: %s", comment)
+	}
+}
+
 func TestPullLedgerReferencePublishesPullLinkAndTitle(t *testing.T) {
 	reference := buildPullLedgerReference(
 		"tsk_0041",

--- a/backend/internal/core/admin_ledger.go
+++ b/backend/internal/core/admin_ledger.go
@@ -3,6 +3,7 @@ package core
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 )
@@ -42,13 +43,35 @@ func (s *Server) createAdminLedgerCredit(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	s.broadcastLiveFeedEvent("ledger_manual_credit")
+	creditURL := scanAccountURL(s.cfg, entry.ToAccount)
 	writeJSON(w, http.StatusCreated, AdminManualCreditResponse{
-		LedgerEntry: entry,
-		WorkerID:    workerID,
-		RewardMRG:   rewardMRG,
-		BountyType:  bountyType,
-		CreditURL:   scanAccountURL(s.cfg, entry.ToAccount),
+		LedgerEntry:    entry,
+		WorkerID:       workerID,
+		RewardMRG:      rewardMRG,
+		BountyType:     bountyType,
+		CreditURL:      creditURL,
+		ScanURL:        creditURL,
+		LedgerSequence: entry.Sequence,
+		ProofHash:      entry.EntryHash,
+		CommentTemplate: renderManualCreditComment(workerID, rewardMRG, bountyType, creditURL, entry.Sequence, entry.EntryHash, req.PRURL),
 	})
+}
+
+func renderManualCreditComment(workerID string, rewardMRG int64, bountyType string, creditURL string, sequence int, proofHash, prURL string) string {
+	mergeURL := prURL
+	if mergeURL == "" {
+		mergeURL = "manual-credit"
+	}
+	return fmt.Sprintf(`MergeOS manual credit approved.
+
+- Merge URL: %s
+- MRG credit URL: %s
+- Credited worker: %s
+- Bounty type: %s
+- MRG credited: %d MRG
+- Ledger sequence: %d
+- Proof hash: %s
+`, mergeURL, creditURL, workerID, adminBountyTitle(bountyType), rewardMRG, sequence, proofHash)
 }
 
 func selectedManualCreditRewardMRG(req AdminManualCreditRequest) int64 {

--- a/backend/internal/core/models.go
+++ b/backend/internal/core/models.go
@@ -722,11 +722,15 @@ type AdminManualCreditRequest struct {
 }
 
 type AdminManualCreditResponse struct {
-	LedgerEntry LedgerEntry `json:"ledger_entry"`
-	WorkerID    string      `json:"worker_id"`
-	RewardMRG   int64       `json:"reward_mrg"`
-	BountyType  string      `json:"bounty_type"`
-	CreditURL   string      `json:"credit_url,omitempty"`
+	LedgerEntry     LedgerEntry `json:"ledger_entry"`
+	WorkerID        string      `json:"worker_id"`
+	RewardMRG       int64       `json:"reward_mrg"`
+	BountyType      string      `json:"bounty_type"`
+	CreditURL       string      `json:"credit_url,omitempty"`
+	ScanURL         string      `json:"scan_url,omitempty"`
+	LedgerSequence  int         `json:"ledger_sequence"`
+	ProofHash       string      `json:"proof_hash,omitempty"`
+	CommentTemplate string      `json:"comment_template,omitempty"`
 }
 
 type StatusResponse struct {

--- a/backend/internal/core/store_test.go
+++ b/backend/internal/core/store_test.go
@@ -6747,6 +6747,27 @@ func TestAdminCanCreateManualLedgerCredit(t *testing.T) {
 	if !strings.Contains(payload.CreditURL, "/address/github:eliasx45") {
 		t.Fatalf("manual credit URL = %q", payload.CreditURL)
 	}
+	if payload.ScanURL != payload.CreditURL {
+		t.Fatalf("manual credit scan_url should equal credit_url, got scan_url=%q credit_url=%q", payload.ScanURL, payload.CreditURL)
+	}
+	if payload.LedgerSequence != payload.LedgerEntry.Sequence {
+		t.Fatalf("manual credit ledger_sequence = %d, want %d", payload.LedgerSequence, payload.LedgerEntry.Sequence)
+	}
+	if payload.ProofHash != payload.LedgerEntry.EntryHash {
+		t.Fatalf("manual credit proof_hash = %q, want %q", payload.ProofHash, payload.LedgerEntry.EntryHash)
+	}
+	if payload.CommentTemplate == "" {
+		t.Fatal("manual credit comment_template is empty")
+	}
+	if !strings.Contains(payload.CommentTemplate, "github:eliasx45") {
+		t.Fatalf("manual credit comment_template missing worker: %q", payload.CommentTemplate)
+	}
+	if !strings.Contains(payload.CommentTemplate, "50 MRG") {
+		t.Fatalf("manual credit comment_template missing reward: %q", payload.CommentTemplate)
+	}
+	if !strings.Contains(payload.CommentTemplate, "Future bounty - medium") {
+		t.Fatalf("manual credit comment_template missing bounty type title: %q", payload.CommentTemplate)
+	}
 	foundPublicReference := false
 	for _, entry := range store.ListPublicLedger() {
 		if entry.Type == "manual_credit" && entry.Reference == payload.LedgerEntry.Reference {


### PR DESCRIPTION
## Summary

This PR improves the admin manual credit UX by:

1. Backend: Adding `comment_template`, `scan_url`, `ledger_sequence`, and `proof_hash` to the AdminManualCreditResponse API response
2. Frontend: Displaying a credit result card after manual credit with worker, MRG amount, ledger sequence (linked to scan URL), proof hash, bounty type, and a copyable comment template

## Changes

### Backend (admin_ledger.go)
- Added `renderManualCreditComment()` function that formats a standard credit comment matching the maintainer format
- Updated `createAdminLedgerCredit` to return the new fields

### Backend (models.go)
- Extended `AdminManualCreditResponse` with: `ScanURL`, `LedgerSequence`, `ProofHash`, `CommentTemplate`

### Frontend (App.vue)
- Added credit result card with details after manual credit
- Added "Copy comment" button for maintainers to copy the standard comment template to clipboard
- Added `manualCreditResult` and `commentCopied` reactive refs
- Added `copyCreditComment()` function

### Frontend (styles.css)
- Added CSS for credit result card, comment preview, and copy button

### Tests (admin_github_test.go)
- Added `TestRenderManualCreditCommentIncludesAllFields` - verifies all comment fields
- Added `TestRenderManualCreditCommentFallbackPRURL` - verifies fallback when no PR URL

### Tests (store_test.go)
- Updated `TestAdminCanCreateManualLedgerCredit` to verify `ScanURL`, `LedgerSequence`, `ProofHash`, and `CommentTemplate`

## Acceptance Criteria

- [x] Preset bounty types map to 25/50/100/200 (already existed)
- [x] After credit, show ledger sequence + proof hash + scan URL
- [x] Comment template matches maintainer format used on merged bounty PRs
- [x] Basic UI and API tests

## Claim

- GitHub handle: guilhermevanessamarques-svg
- Wallet/token receiver: guilhermevanessamarques-svg
- Linked to issue: #240
