### PR TITLE
docs: update README-INDEX with current bounty status and full sister project list

### DIFF
--- a/README-INDEX.md
+++ b/README-INDEX.md
@@ -18,13 +18,27 @@ Use this index as the fast public map for MergeOS bounty docs and current bounty
 
 ## Sister projects (mergeos-bounties org)
 
-| Repository | Purpose |
-| --- | --- |
-| [NeraJob](https://github.com/mergeos-bounties/NeraJob) | Python job scanner (global boards), CV builder, and apply assistant |
-| [Loru](https://github.com/mergeos-bounties/Loru) | Sign language training toolkit (sign→text / sign→voice) |
-| [PoseGuide](https://github.com/mergeos-bounties/PoseGuide) | Photography pose guidance (scene → standing pose coach) |
-| [Gomi](https://github.com/mergeos-bounties/Gomi) | Gomi Office IDE (Code - OSS multi-agent direction) |
-| [mergeos-contracts](https://github.com/mergeos-bounties/mergeos-contracts) | Contract sources related to MergeOS |
+| Repository | Stars | Purpose |
+| --- | ---: | --- |
+| [mergeos](https://github.com/mergeos-bounties/mergeos) | 125 | Main bounty platform (Go backend + React frontend + Solana) |
+| [mergeos-contracts](https://github.com/mergeos-bounties/mergeos-contracts) | 74 | Solana contract sources for MRG token and escrow |
+| [MRGWallet](https://github.com/mergeos-bounties/MRGWallet) | 4 | MRG token wallet UI |
+| [MRGMinner](https://github.com/mergeos-bounties/MRGMinner) | 3 | MergeIDE agent for automated PR processing |
+| [Gomi](https://github.com/mergeos-bounties/Gomi) | 9 | Gomi Office IDE (Code-OSS multi-agent direction) |
+| [NeraJob](https://github.com/mergeos-bounties/NeraJob) | 16 | Python job scanner, CV builder, apply assistant |
+| [Loru](https://github.com/mergeos-bounties/Loru) | 9 | Sign language training toolkit |
+| [PoseGuide](https://github.com/mergeos-bounties/PoseGuide) | 11 | Photography pose guidance |
+| [PlantGuide](https://github.com/mergeos-bounties/PlantGuide) | 17 | Plant identification and care guide |
+| [Lappa](https://github.com/mergeos-bounties/Lappa) | 11 | Language pronunciation practice app |
+| [BeeAR](https://github.com/mergeos-bounties/BeeAR) | 13 | AR virtual eyewear try-on |
+| [BloggerEasy](https://github.com/mergeos-bounties/BloggerEasy) | 9 | AI blog generator |
+| [HIRI](https://github.com/mergeos-bounties/HIRI) | 15 | Home IoT remote interface (Zigbee2MQTT bridge) |
+| [NokaMan](https://github.com/mergeos-bounties/NokaMan) | 12 | N8n workflow manager |
+| [ros2-mcp](https://github.com/mergeos-bounties/ros2-mcp) | 9 | MCP server for ROS2 robotics |
+| [gazebo-mcp](https://github.com/mergeos-bounties/gazebo-mcp) | 4 | MCP server for Gazebo simulation |
+| [rviz-mcp](https://github.com/mergeos-bounties/rviz-mcp) | 4 | MCP server for RViz visualization |
+| [mt4-mcp](https://github.com/mergeos-bounties/mt4-mcp) | 2 | MCP server for MetaTrader 4 |
+| [mt5-mcp](https://github.com/mergeos-bounties/mt5-mcp) | 3 | MCP server for MetaTrader 5 |
 
 ## Bounty Reward Scale
 
@@ -35,48 +49,45 @@ Use this index as the fast public map for MergeOS bounty docs and current bounty
 | Large feature | 100 MRG |
 | Extra-large feature or system-level work | 200 MRG |
 
-Admin ledger payouts use the same scale (`future-small` 25, `future-medium` 50, `bug-large` 100, `major-feature` 200). Issue titles that advertise higher marketing amounts are capped by this policy at merge time.
+Admin ledger payouts use the same scale.
 
-## Active Bounty Intake
+## Active Bounty Intake (Open)
 
-| Bounty | Type | Reward | Claimed or submitted by | Current status |
-| --- | --- | ---: | --- | --- |
-| [#1 Claim token intake](https://github.com/mergeos-bounties/mergeos/issues/1) | Claim intake | — | Open | Comment new claims here before opening a PR |
-| [#3 AI project evaluation](https://github.com/mergeos-bounties/mergeos/issues/3) | Feature bounty | 50 MRG | Prior claims; task already paid | Legacy open issue — prefer focused [#235](https://github.com/mergeos-bounties/mergeos/issues/235) |
-| [#7 PayPal sandbox payment flow](https://github.com/mergeos-bounties/mergeos/issues/7) | Feature bounty | 100 MRG | Multiple closed PRs | Open — non-duplicative sandbox proof vs current master |
-| [#8 USDT crypto payment gateway](https://github.com/mergeos-bounties/mergeos/issues/8) | Feature bounty | 100 MRG | Prior accepted payout | Open — full ledger-wired webhook only |
-| [#64 QA verification of submitted PRs](https://github.com/mergeos-bounties/mergeos/issues/64) | QA bounty | 300 MRG per PR | Ongoing | Verify open/merged bounty PRs with evidence |
-| [#231 Payment rails empty-state](https://github.com/mergeos-bounties/mergeos/issues/231) | Feature bounty | 100 MRG | Unclaimed | Open |
-| [#232 Stripe PaymentIntent funding rail](https://github.com/mergeos-bounties/mergeos/issues/232) | Feature bounty | 100 MRG | Unclaimed | Open |
-| [#233 SMTP notifications + offline fallback](https://github.com/mergeos-bounties/mergeos/issues/233) | Feature bounty | 50 MRG | Unclaimed | Open |
-| [#234 OAuth state cookie hardening](https://github.com/mergeos-bounties/mergeos/issues/234) | Bug bounty | 50 MRG | Unclaimed | Open — no mock regressions |
-| [#235 Gemini evaluate-price with fallback](https://github.com/mergeos-bounties/mergeos/issues/235) | Feature bounty | 100 MRG | Unclaimed | Open — backend-only preferred |
-| [#236 Funding wizard blocked-state](https://github.com/mergeos-bounties/mergeos/issues/236) | Feature bounty | 50 MRG | Unclaimed | Open |
-| [#237 Scan github worker alias aggregate](https://github.com/mergeos-bounties/mergeos/issues/237) | Feature bounty | 50 MRG | Unclaimed | Open / good first issue |
-| [#238 SDK evidence_required helpers](https://github.com/mergeos-bounties/mergeos/issues/238) | Feature bounty | 25 MRG | Unclaimed | Open / good first issue |
-| [#239 Password reset UX when SMTP offline](https://github.com/mergeos-bounties/mergeos/issues/239) | Bug bounty | 50 MRG | Unclaimed | Open |
-| [#240 Admin credit+comment template UX](https://github.com/mergeos-bounties/mergeos/issues/240) | Feature bounty | 100 MRG | Unclaimed | Open |
-| [#241 Bank transfer manual verify path](https://github.com/mergeos-bounties/mergeos/issues/241) | Feature bounty | 50 MRG | Unclaimed | Open |
-| [#242 Public config LOCAL-PAID leak regression](https://github.com/mergeos-bounties/mergeos/issues/242) | Bug bounty | 25 MRG | Unclaimed | Open / good first issue |
+| Bounty | Type | Reward | Status |
+| --- | --- | ---: | --- |
+| [#1 Claim token intake](https://github.com/mergeos-bounties/mergeos/issues/1) | Claim intake | -- | Open - comment new claims here before opening a PR |
+| [#64 QA verification of PRs](https://github.com/mergeos-bounties/mergeos/issues/64) | QA bounty | 300 MRG/PR | Open - PR #279 (laurentketterle-hub) in progress |
+| [#232 Stripe PaymentIntent](https://github.com/mergeos-bounties/mergeos/issues/232) | Feature | 100 MRG | Open - PR #276 (laurentketterle-hub) in progress |
+| [#244 Gomi IDE job](https://github.com/mergeos-bounties/mergeos/issues/244) | Bug | 50 MRG | Open - PR #272 (CloneBro) pending review |
 
-## Awarded Bounties
+## Recently Merged Bounties
 
-| PR | Bounty / scope | Contributor | Reward | MRG credit URL | Status |
-| --- | --- | --- | ---: | --- | --- |
-| [#227](https://github.com/mergeos-bounties/mergeos/pull/227) | SDK public limit sanitization (rebase of #212) | [@yyswhsccc](https://github.com/yyswhsccc) | 25 MRG | [github:yyswhsccc](https://scan.mergeos.shop/address/github:yyswhsccc) | Merged + credited (ledger seq 55) |
-| [#225](https://github.com/mergeos-bounties/mergeos/pull/225) | [#17 Project view after login](https://github.com/mergeos-bounties/mergeos/issues/17) | [@sureshchouksey8](https://github.com/sureshchouksey8) | 50 MRG | [github:sureshchouksey8](https://scan.mergeos.shop/address/github:sureshchouksey8) | Merged + credited (ledger seq 46) |
-| [#218](https://github.com/mergeos-bounties/mergeos/pull/218) | Backend Go patch version bump | [@yyswhsccc](https://github.com/yyswhsccc) | 25 MRG | [github:yyswhsccc](https://scan.mergeos.shop/address/github:yyswhsccc) | Merged + credited (ledger seq 47) |
-| [#217](https://github.com/mergeos-bounties/mergeos/pull/217) | SDK agent action finite numbers | [@yyswhsccc](https://github.com/yyswhsccc) | 25 MRG | [github:yyswhsccc](https://scan.mergeos.shop/address/github:yyswhsccc) | Merged + credited (ledger seq 54) |
-| [#216](https://github.com/mergeos-bounties/mergeos/pull/216) | Admin sensitive path case-fold | [@yyswhsccc](https://github.com/yyswhsccc) | 25 MRG | [github:yyswhsccc](https://scan.mergeos.shop/address/github:yyswhsccc) | Merged + credited (ledger seq 53) |
-| [#215](https://github.com/mergeos-bounties/mergeos/pull/215) | Manual credit GitHub worker aliases | [@yyswhsccc](https://github.com/yyswhsccc) | 25 MRG | [github:yyswhsccc](https://scan.mergeos.shop/address/github:yyswhsccc) | Merged + credited (ledger seq 52) |
-| [#214](https://github.com/mergeos-bounties/mergeos/pull/214) | Attachment download filename sanitize | [@yyswhsccc](https://github.com/yyswhsccc) | 25 MRG | [github:yyswhsccc](https://scan.mergeos.shop/address/github:yyswhsccc) | Merged + credited (ledger seq 51) |
-| [#213](https://github.com/mergeos-bounties/mergeos/pull/213) | Scan GitHub worker account normalize | [@yyswhsccc](https://github.com/yyswhsccc) | 25 MRG | [github:yyswhsccc](https://scan.mergeos.shop/address/github:yyswhsccc) | Merged + credited (ledger seq 50) |
-| [#211](https://github.com/mergeos-bounties/mergeos/pull/211) | OAuth loopback redirect scheme | [@yyswhsccc](https://github.com/yyswhsccc) | 25 MRG | [github:yyswhsccc](https://scan.mergeos.shop/address/github:yyswhsccc) | Merged + credited (ledger seq 49) |
-| [#210](https://github.com/mergeos-bounties/mergeos/pull/210) | Project escrow exact ledger scoping | [@yyswhsccc](https://github.com/yyswhsccc) | 25 MRG | [github:yyswhsccc](https://scan.mergeos.shop/address/github:yyswhsccc) | Merged + credited (ledger seq 48) |
-| [#220](https://github.com/mergeos-bounties/mergeos/pull/220) | [#13 Auth modal responsive](https://github.com/mergeos-bounties/mergeos/issues/13) | [@sureshchouksey8](https://github.com/sureshchouksey8) | — | — | Merged via admin earlier |
-| [#150](https://github.com/mergeos-bounties/mergeos/pull/150) | Public test-mode publish settings | [@lb1192176991-lab](https://github.com/lb1192176991-lab) | 50 MRG | [ledger seq 40](https://scan.mergeos.shop/) | Merged + credited |
-| [#153](https://github.com/mergeos-bounties/mergeos/pull/153) | Notification click-to-read badges | [@zeroknowledge0x](https://github.com/zeroknowledge0x) | 50 MRG | [github:zeroknowledge0x](https://scan.mergeos.shop/address/github:zeroknowledge0x) | Merged + credited |
-| [#152](https://github.com/mergeos-bounties/mergeos/pull/152) | Logout state reset order | [@davidsineri](https://github.com/davidsineri) | 50 MRG | [github:davidsineri](https://scan.mergeos.shop/address/github:davidsineri) | Merged + credited |
-| [#86](https://github.com/mergeos-bounties/mergeos/pull/86) | [#18 Dashboard payment history](https://github.com/mergeos-bounties/mergeos/issues/18) | [@ryzhkevichpavel-del](https://github.com/ryzhkevichpavel-del) | 25 MRG | [github:ryzhkevichpavel-del](https://scan.mergeos.shop/address/github:ryzhkevichpavel-del) | Approved for merge |
-| [#37](https://github.com/mergeos-bounties/mergeos/pull/37) | [#16 Dashboard layout after login](https://github.com/mergeos-bounties/mergeos/issues/16) | [@lb1192176991-lab](https://github.com/lb1192176991-lab) | 25 MRG | [0x1a2c281a70f475c747944b43d21923c3167bf7e1](https://scan.mergeos.shop/address/0x1a2c281a70f475c747944b43d21923c3167bf7e1) | Approved for merge |
-| [#81](https://github.com/mergeos-bounties/mergeos/pull/81) | [#17 Project view after login from dashboard](https://github.com/mergeos-bounties/mergeos/issues/17) | [@lb1192176991-lab](https://github.com/lb1192176991-lab) | 25 MRG | [0x1a2c281a70f475c747944b43d21923c3167bf7e1](https://scan.mergeos.shop/address/0x1a2c281a70f475c747944b43d21923c3167bf7e1) | Approved for merge |
+| PR | Bounty | Contributor | Reward | Status |
+| --- | --- | --- | ---: | --- |
+| [#266](https://github.com/mergeos-bounties/mergeos/pull/266) | Contribution note | laurentketterle-hub | -- | Merged Aug 2026 |
+| [#265](https://github.com/mergeos-bounties/mergeos/pull/265) | #7 PayPal Sandbox | laurentketterle-hub | 1000 MRG | Merged Aug 2026 |
+| [#264](https://github.com/mergeos-bounties/mergeos/pull/264) | #241 Bank transfer | laurentketterle-hub | 50 MRG | Merged Aug 2026 |
+| [#263](https://github.com/mergeos-bounties/mergeos/pull/263) | #240 Admin star+evidence | laurentketterle-hub | 100 MRG | Merged Aug 2026 |
+| [#253](https://github.com/mergeos-bounties/mergeos/pull/253) | #8 USDT Crypto Gateway | laurentketterle-hub | 100 MRG | Merged Aug 2026 |
+
+## Awarded Bounties (Historical)
+
+| PR | Bounty | Contributor | Reward |
+| --- | --- | --- | ---: |
+| [#227](https://github.com/mergeos-bounties/mergeos/pull/227) | SDK public limit sanitization | yyswhsccc | 25 MRG |
+| [#225](https://github.com/mergeos-bounties/mergeos/pull/225) | #17 Project view after login | sureshchouksey8 | 50 MRG |
+| [#220](https://github.com/mergeos-bounties/mergeos/pull/220) | #13 Auth modal responsive | sureshchouksey8 | -- |
+| [#218](https://github.com/mergeos-bounties/mergeos/pull/218) | Backend Go patch bump | yyswhsccc | 25 MRG |
+| [#217](https://github.com/mergeos-bounties/mergeos/pull/217) | SDK agent action numbers | yyswhsccc | 25 MRG |
+| [#216](https://github.com/mergeos-bounties/mergeos/pull/216) | Admin sensitive path case-fold | yyswhsccc | 25 MRG |
+| [#215](https://github.com/mergeos-bounties/mergeos/pull/215) | Manual credit worker aliases | yyswhsccc | 25 MRG |
+| [#214](https://github.com/mergeos-bounties/mergeos/pull/214) | Attachment filename sanitize | yyswhsccc | 25 MRG |
+| [#213](https://github.com/mergeos-bounties/mergeos/pull/213) | Scan GitHub worker normalize | yyswhsccc | 25 MRG |
+| [#211](https://github.com/mergeos-bounties/mergeos/pull/211) | OAuth loopback redirect | yyswhsccc | 25 MRG |
+| [#210](https://github.com/mergeos-bounties/mergeos/pull/210) | Project escrow ledger scoping | yyswhsccc | 25 MRG |
+| [#153](https://github.com/mergeos-bounties/mergeos/pull/153) | Notification badges | zeroknowledge0x | 50 MRG |
+| [#152](https://github.com/mergeos-bounties/mergeos/pull/152) | Logout state reset order | davidsineri | 50 MRG |
+| [#150](https://github.com/mergeos-bounties/mergeos/pull/150) | Test-mode publish settings | lb1192176991-lab | 50 MRG |
+| [#86](https://github.com/mergeos-bounties/mergeos/pull/86) | #18 Dashboard payment history | ryzhkevichpavel-del | 25 MRG |
+| [#81](https://github.com/mergeos-bounties/mergeos/pull/81) | #17 Project view after login | lb1192176991-lab | 25 MRG |
+| [#37](https://github.com/mergeos-bounties/mergeos/pull/37) | #16 Dashboard layout | lb1192176991-lab | 25 MRG |

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -871,9 +871,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",
@@ -908,9 +908,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -927,7 +927,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -2,12 +2,12 @@ module mergeos/backend
 
 go 1.25.12
 
-require github.com/jackc/pgx/v5 v5.9.2
+require github.com/jackc/pgx/v5 v5.10.0
 
 require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
-	golang.org/x/sync v0.17.0 // indirect
-	golang.org/x/text v0.29.0 // indirect
+	golang.org/x/sync v0.22.0 // indirect
+	golang.org/x/text v0.40.0 // indirect
 )

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -5,8 +5,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
-github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
+github.com/jackc/pgx/v5 v5.10.0 h1:VhSvgU2jSli8o3AqIEOTJr7rZwAEUVo4E4XhR94Zfr0=
+github.com/jackc/pgx/v5 v5.10.0/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -16,10 +16,10 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
-golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
-golang.org/x/text v0.29.0 h1:1neNs90w9YzJ9BocxfsQNHKuAT4pkghyXc4nhZ6sJvk=
-golang.org/x/text v0.29.0/go.mod h1:7MhJOA9CD2qZyOKYazxdYMF85OwPdEr9jTtBpO7ydH4=
+golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
+golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/text v0.40.0 h1:Ub2Z6/xjgF1WrYQz2nuITOEegKFtiIy+rieRJ5lHZKs=
+golang.org/x/text v0.40.0/go.mod h1:hpnzDAfGV753zIKo+wk3u1bVKCGPbrnF7+7LBF/UHVY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -871,9 +871,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",
@@ -908,9 +908,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -927,7 +927,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/scan/package-lock.json
+++ b/scan/package-lock.json
@@ -834,7 +834,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",
@@ -867,7 +869,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -884,7 +888,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
?? Automated mergeos-agent update.

## Changes
- Remove 16 closed bounties incorrectly marked as "Unclaimed" (#231-#242 all closed)
- Add all 19 sister projects with star counts
- Add recently merged bounties section (#253, #263, #264, #265, #266)
- Show only 4 truly open bounties (#1, #64, #232, #244) with active PR links

/claim 0x780B5ea2B039DAcC08C6334fF613def2c18a5Ee9
