### PR TITLE
fix(ci): resolve security vulnerabilities blocking all PRs

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -871,9 +871,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",
@@ -908,9 +908,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -927,7 +927,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/admin/package.json
+++ b/admin/package.json
@@ -19,5 +19,8 @@
   "devDependencies": {
     "@vitejs/plugin-vue": "6.0.7",
     "vite": "8.0.16"
+  },
+  "overrides": {
+    "postcss": "8.5.26"
   }
 }

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -8,6 +8,6 @@ require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
-	golang.org/x/sync v0.17.0 // indirect
-	golang.org/x/text v0.29.0 // indirect
+	golang.org/x/sync v0.21.0 // indirect
+	golang.org/x/text v0.39.0 // indirect
 )

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -16,10 +16,10 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
-golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
-golang.org/x/text v0.29.0 h1:1neNs90w9YzJ9BocxfsQNHKuAT4pkghyXc4nhZ6sJvk=
-golang.org/x/text v0.29.0/go.mod h1:7MhJOA9CD2qZyOKYazxdYMF85OwPdEr9jTtBpO7ydH4=
+golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
+golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/text v0.39.0 h1:UbZz4pLOvn600D6Oh6GGEI6VAmndrEBLv8/6BEXzyus=
+golang.org/x/text v0.39.0/go.mod h1:3UwRclnC2g0TU9x8PZiyfOajCd1zaUNHF9cvqcQZ+ZM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -871,9 +871,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",
@@ -908,9 +908,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -927,7 +927,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,5 +21,8 @@
   "devDependencies": {
     "@vitejs/plugin-vue": "6.0.7",
     "vite": "8.0.16"
+  },
+  "overrides": {
+    "postcss": "8.5.26"
   }
 }

--- a/scan/package-lock.json
+++ b/scan/package-lock.json
@@ -834,7 +834,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",
@@ -867,7 +869,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -884,7 +888,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/scan/package.json
+++ b/scan/package.json
@@ -17,5 +17,8 @@
   "devDependencies": {
     "@vitejs/plugin-vue": "6.0.7",
     "vite": "8.0.16"
+  },
+  "overrides": {
+    "postcss": "8.5.26"
   }
 }


### PR DESCRIPTION
## 🔒 Fixes CI failures across ALL open PRs

### Problème
**8 PRs ouvertes** sont en échec CI à cause de 2 vulnérabilités de sécurité systémiques :

| PR | Auteur | Échecs |
|-----|--------|--------|
| #250 | elevasyncsolutions-jpg | Backend |
| #259 | chfr19820610-cell | Backend + Web |
| #262 | elevasyncsolutions-jpg | Backend |
| #268 | CloneBro | Backend |
| #271 | CloneBro | Backend + Web |
| #272 | CloneBro | Backend + Web |
| #273 | waterWang | Backend + Web + Secret scan |
| #280 | waterWang | Backend + Web |

### Causes

#### 1. Backend : `golang.org/x/text` vulnérabilité
- **Outil** : `govulncheck` (GO-2026-5970)
- **Problème** : Infinite loop on invalid input in `golang.org/x/text`
- **Version actuelle** : v0.29.0
- **Version corrigée** : v0.39.0
- **Fix** : `go get golang.org/x/text@v0.39.0`

#### 2. Web (admin/frontend/scan) : `postcss` vulnérabilité
- **Outil** : `npm audit --audit-level=high` (GHSA-r28c-9q8g-f849)
- **Problème** : Path Traversal in PostCSS source map auto-loading
- **Version actuelle** : 8.5.15 (transitive via Vite)
- **Version corrigée** : 8.5.26
- **Fix** : Ajout d'override npm `"postcss": "8.5.26"` dans les 3 `package.json`

### Changements
- `backend/go.mod` : upgrade golang.org/x/text v0.29.0 → v0.39.0 (+ go.sum)
- `admin/package.json` : add overrides postcss 8.5.26 (+ lock)
- `frontend/package.json` : add overrides postcss 8.5.26 (+ lock)
- `scan/package.json` : add overrides postcss 8.5.26 (+ lock)

### ⚠️ Attention PR #273
La PR #273 a un échec **supplémentaire** sur le `Secret scan` (gitleaks a détecté des secrets commités). Ce fix ne résout PAS ce problème — l'auteur doit retirer les credentials de son code.